### PR TITLE
[WIP][DO NOT MERGE] Test OS random APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
   include:
     - {os: linux, d: ldc-1.1.0-beta5, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: dmd, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
-branches:
-  only:
-    - master
 script:
  - dub test --arch "$ARCH"
  - dub build --root=examples/flex_plot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,6 @@ environment:
     arch: x64
 
 skip_tags: true
-branches:
-  only:
-    - master
-    - stable
-
 install:
   - ps: function SetUpDCompiler
         {

--- a/dub.json
+++ b/dub.json
@@ -7,8 +7,11 @@
 	],
 	"description": "Dlang Random Number Generators",
 	"copyright": "Copyright © 2016, Ilya Yaroshenko",
-	"license": "BSL-1.0",
+	"license": "BSD 3-clause",
 	"dependencies": {
 		"mir-math": "~>0.0.1"
 	}
+	"libs-windows" : [
+    "advapi32"
+	]
 }

--- a/source/mir/random/engine/test.d
+++ b/source/mir/random/engine/test.d
@@ -1,0 +1,232 @@
+module mir.random.engine.test;
+
+import std.typecons;
+import std.stdio;
+
+version(linux) version(X86_64)
+{
+    shared static this()
+    {
+        hasGetRandom = initHasGetRandom;
+    }
+
+    private static bool hasGetRandom;
+
+    auto initHasGetRandom()
+    {
+        import core.sys.posix.sys.utsname;
+        utsname uts;
+        uname(&uts);
+
+        import std.algorithm.iteration : splitter;
+        import std.conv : to;
+
+        auto release = uts.release[].splitter(".");
+        if (release.front.to!int > 3)
+            return true;
+        release.popFront;
+        if (release.front.to!int > 17)
+            return true;
+        return false;
+    }
+
+    /*
+     * Flags for getrandom(2)
+     *
+     * GRND_NONBLOCK	Don't block and return EAGAIN instead
+     * GRND_RANDOM		Use the /dev/random pool instead of /dev/urandom
+     */
+    enum GRND_NONBLOCK = 0x0001;
+    enum GRND_RANDOM = 0x0002;
+    enum GETRANDOM = 318;
+
+    size_t syscall(size_t ident, size_t n, size_t arg1, size_t arg2)
+    {
+        size_t ret;
+
+        synchronized asm
+        {
+            mov RAX, ident;
+            mov RDI, n[RBP];
+            mov RSI, arg1[RBP];
+            mov RDX, arg2[RBP];
+            syscall;
+            mov ret, RAX;
+        }
+        return ret;
+    }
+
+    bool getRandomImplSys(Flag!"blocking" blocking)(ubyte[] buffer)
+    {
+        import core.stdc.errno : EAGAIN;
+        static if (blocking)
+        {
+            syscall(GETRANDOM, cast(size_t) &buffer[0], r.sizeof, 0);
+            return 0;
+        }
+        else
+        {
+            if (syscall(GETRANDOM, cast(size_t) &buffer[0], buffer.length, 0) != EAGAIN)
+                return 0;
+            else
+                return 1;
+        }
+    }
+}
+
+version(Posix)
+{
+    import core.stdc.stdio : fopen;
+    alias IOType = typeof(fopen("a", "b"));
+    static private IOType randFd;
+
+    shared static ~this()
+    {
+        if (randFd !is null)
+            fclose(randFd);
+    }
+
+    // TODO: use syscalls here as well?
+    private bool getRandomImplFile(Flag!"blocking" blocking)(ubyte[] buffer)
+    {
+        if (randFd !is null)
+        {
+            static if (blocking)
+                randFd = fopen("/dev/random", "r");
+            else
+                randFd = fopen("/dev/urandom", "r");
+        }
+
+        auto genBytes = 0;
+        while (genBytes < buffer.length)
+        {
+            size_t res = fread(buffer.ptr + genBytes, buffer.length - genBytes, 1, randFd);
+            genBytes -= res;
+        }
+        return 0;
+    }
+
+    version(linux)
+    {
+        version(X86_64)
+        {
+            private void getRandomImpl(Flag!"blocking" blocking)(ubyte[] buffer)
+            {
+                if (hasGetRandom)
+                    getRandomImplSys!(blocking)(buffer);
+                else
+                    // fallback for older Linux versions
+                    getRandomImplFile!(blocking)(buffer);
+            }
+        } else {
+            private alias getRandomImpl = getRandomImplFile;
+        }
+    } else {
+        private alias getRandomImpl = getRandomImplFile;
+    }
+}
+
+version(Windows)
+{
+
+    version(DigitalMars)
+    pragma(lib, "Advapi32.lib");
+
+    import core.sys.windows.wincrypt : HCRYPTPROV;
+    private static HCRYPTPROV hProvider;
+
+    auto initGetRandom()
+    {
+        import core.sys.windows.wincrypt;
+        import core.sys.windows.winbase : GetLastError;
+        import core.sys.windows.winerror : NTE_BAD_KEYSET;
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379886(v=vs.85).aspx
+        // For performance reasons, we recommend that you set the pszContainer
+        // parameter to NULL and the dwFlags parameter to CRYPT_VERIFYCONTEXT
+        // in all situations where you do not require a persisted key.
+        // CRYPT_SILENT is intended for use with applications for which the UI cannot be displayed by the CSP.
+	    if (!CryptAcquireContextW(&hProvider, null, null, PROV_RSA_FULL, 0))
+	    {
+	        writeln("FAIL");
+            if (GetLastError() == NTE_BAD_KEYSET)
+            {
+                // No default container was found. Attempt to create it.
+                if (!CryptAcquireContext(&hProvider, null, null, PROV_RSA_FULL, CRYPT_NEWKEYSET))
+                    return 1;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    shared static ~this()
+    {
+        import core.sys.windows.wincrypt : CryptReleaseContext;
+        if (hProvider > 0)
+		    CryptReleaseContext(hProvider, 0);
+    }
+
+    private bool getRandomImpl(Flag!"blocking" blocking)(ubyte[] buffer)
+    {
+        import core.sys.windows.wincrypt : CryptGenRandom;
+        import core.sys.windows.winbase : GetLastError;
+        import core.sys.windows.winerror : ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER, NTE_BAD_UID, NTE_FAIL;
+
+        if (hProvider == 0)
+            if (initGetRandom != 0)
+                return 1;
+
+        writeln("win.getRandom: ", hProvider);
+
+	    if (!CryptGenRandom(hProvider, cast(uint) buffer.length, buffer.ptr))
+	    {
+	        writeln("buffer", buffer);
+	        switch(GetLastError())
+	        {
+                case ERROR_INVALID_HANDLE:
+                    writeln("invalid handle");
+                    break;
+                case ERROR_INVALID_PARAMETER:
+                    writeln("invalid params");
+                    break;
+                case NTE_BAD_UID:
+                    writeln("bad_uid");
+                    break;
+                case NTE_FAIL:
+                    writeln("nte_fail");
+                    break;
+                default:
+                    writeln("fail");
+            }
+
+		    return 1;
+	    }
+		return 0;
+	}
+}
+
+auto getRandom(Flag!"blocking" blocking = No.blocking, Flag!"raise" raise = No.raise)(ubyte[] buffer)
+{
+    static if (raise)
+    {
+        if (getRandomImpl!(blocking)(buffer))
+            throw new Exception("Random error");
+    }
+    else
+    {
+        return getRandomImpl!(blocking)(buffer);
+    }
+}
+
+unittest
+{
+    import std.stdio;
+    ubyte[] buf = new ubyte[4];
+    getRandom(buf);
+    writeln(buf);
+}

--- a/source/mir/random/engine/test2.d
+++ b/source/mir/random/engine/test2.d
@@ -1,0 +1,148 @@
+module mir.random.engine.test2;
+
+import std.conv : text;
+import std.digest.sha;
+import core.sys.windows.wincrypt;
+import std.stdio;
+import core.sys.windows.winbase : GetLastError;
+import core.sys.windows.winerror;
+
+alias DWORD = uint;
+
+final class SystemRNG {
+	version(Windows)
+	{
+		//cryptographic service provider
+		private HCRYPTPROV hCryptProv;
+	}
+	else version(Posix)
+	{
+		private import std.stdio;
+		private import std.exception;
+
+		//cryptographic file stream
+		private File file;
+	}
+	else
+	{
+		static assert(0, "OS is not supported");
+	}
+
+	/**
+		Creates new system random generator
+	*/
+	this()
+	{
+		version(Windows)
+		{
+			//init cryptographic service provider
+			if(0 == CryptAcquireContext(&this.hCryptProv, null, null, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+			{
+				writeln(text("Cannot init SystemRNG: Error id is ", GetLastError()));
+			}
+		}
+		else version(Posix)
+		{
+			try
+			{
+				//open file
+				this.file = File("/dev/urandom");
+				//do not use buffering stream to avoid possible attacks
+				this.file.setvbuf(null, _IONBF);
+			}
+			catch(ErrnoException e)
+			{
+				writeln(text("Cannot init SystemRNG: Error id is ", e.errno, `, Error message is: "`, e.msg, `"`));
+			}
+			catch(Exception e)
+			{
+				writeln(text("Cannot init SystemRNG: ", e.msg));
+			}
+		}
+	}
+
+	~this()
+	{
+		version(Windows)
+		{
+			CryptReleaseContext(this.hCryptProv, 0);
+		}
+	}
+
+	@property bool empty() { return false; }
+	@property ulong leastSize() { return ulong.max; }
+	@property bool dataAvailableForRead() { return true; }
+	const(ubyte)[] peek() { return null; }
+
+	void read(ubyte[] buffer)
+	in
+	{
+		assert(buffer.length, "buffer length must be larger than 0");
+		assert(buffer.length <= uint.max, "buffer length must be smaller or equal uint.max");
+	}
+	body
+	{
+		version(Windows)
+		{
+			if(0 == CryptGenRandom(this.hCryptProv, cast(DWORD)buffer.length, buffer.ptr))
+			{
+				writeln(text("Cannot get next random number: Error id is ", GetLastError()));
+			}
+		}
+		else version(Posix)
+		{
+			try
+			{
+				this.file.rawRead(buffer);
+			}
+			catch(ErrnoException e)
+			{
+				writeln(text("Cannot get next random number: Error id is ", e.errno, `, Error message is: "`, e.msg, `"`));
+			}
+			catch(Exception e)
+			{
+				writeln(text("Cannot get next random number: ", e.msg));
+			}
+		}
+	}
+}
+
+//test heap-based arrays
+unittest
+{
+	import std.algorithm;
+	import std.range;
+
+	//number random bytes in the buffer
+	enum uint bufferSize = 20;
+
+	//number of iteration counts
+	enum iterationCount = 10;
+
+	auto rng = new SystemRNG();
+
+	//holds the random number
+	ubyte[] rand = new ubyte[bufferSize];
+
+	//holds the previous random number after the creation of the next one
+	ubyte[] prevRadn = new ubyte[bufferSize];
+
+	//create the next random number
+	rng.read(prevRadn);
+
+	assert(!equal(prevRadn, take(repeat(0), bufferSize)), "it's almost unbelievable - all random bytes is zero");
+
+	//take "iterationCount" arrays with random bytes
+	foreach(i; 0..iterationCount)
+	{
+		//create the next random number
+		rng.read(rand);
+
+		assert(!equal(rand, take(repeat(0), bufferSize)), "it's almost unbelievable - all random bytes is zero");
+
+		assert(!equal(rand, prevRadn), "it's almost unbelievable - current and previous random bytes are equal");
+
+		//copy current random bytes for next iteration
+		prevRadn[] = rand[];
+	}
+}

--- a/source/mir/random/engine/test2.d
+++ b/source/mir/random/engine/test2.d
@@ -4,7 +4,7 @@ import std.conv : text;
 import std.digest.sha;
 import core.sys.windows.wincrypt;
 import std.stdio;
-import core.sys.windows.winbase : GetLastError;
+import core.sys.windows.winbase;
 import core.sys.windows.winerror;
 
 alias DWORD = uint;


### PR DESCRIPTION
Hi,

so this is WIP and while it's pretty easy to read random number in Posix, the Windows part is troubling me. While [there's an API](https://msdn.microsoft.com/en-us/library/windows/desktop/aa379942(v=vs.85).aspx) which many implementation use:

C++: http://en.cppreference.com/w/cpp/numeric/random/random_device
LLVM: https://github.com/llvm-mirror/libcxx/blob/master/src/random.cpp
G++: https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/src/c%2B%2B11/random.cc
Python urandom: https://github.com/python/cpython/blob/master/Python/random.c
Vibe.d cryptorand: https://github.com/rejectedsoftware/vibe.d/blob/master/crypto/vibe/crypto/cryptorand.d
pycrypto: https://github.com/dlitz/pycrypto/blob/master/src/winrand.c

I can't get it working on the AppVeyor test instance. For experimentation I also copied `cryptorand` from Vibe.d over and it's unittests are failing as well. I always get `ERROR_INVALID_PARAMETER` which according to the docs stands for:

> One of the parameters contains a value that is not valid. This is most often a pointer that is not valid.

To be honest I haven't used a Windows machine for ages, so if someone has more experience with Windows - it would be greatly appreciated.
Could it be that the linking with `pragma(lib, "Advapi32.lib")` does sth. weird?
Unfortunately specifying the libs via dub didn't work, e.g.:

```
"libs-windows-x86-dmd": ["Advapi32.lib"],
"libs-windows-x86_64-dmd": ["Advapi32.lib"]
```