### PR TITLE
Use Mt19937 only for 32-bit generator

### DIFF
--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -140,7 +140,7 @@ nice random numbers, and (2) you don't care for the minutiae of the
 method being used.
 +/
 static if (is(size_t == uint))
-    alias Random = Mt19937_32;
+    alias Random = Mt19937;
 else
     alias Random = Mt19937_64;
 


### PR DESCRIPTION
This patch corrects the usage of the `Mt19937` symbol to bring it in line with standard definitions for the Mersenne Twister engine, where MT19937 is the name of the standard 32-bit generator and MT19937-64 is the name of the standard 64-bit generator.

The now-obsolete `Mt19937_32` symbol has been removed.

This brings mir.random's API in line with the C++11 standard where the similar template instantiations are called `mt_19937` and `mt_19937_64`.

The `Random` symbol has been updated to alias to `Mt19937` on 32-bit systems and `Mt19937_64` on 64-bit systems.  Some extra example tests have been added to provide separate usage examples for `Mt19937` and `Mt19937_64`.

Fixes libmir/mir-random#19.