### PR TITLE
Fix isSaturatedRandomEngine when opCall is a function template

### DIFF
--- a/source/mir/random/algorithm.d
+++ b/source/mir/random/algorithm.d
@@ -56,7 +56,7 @@ struct RandomField(G)
     +/
     this()(ref G gen) { _gen = &gen; }
     ///
-    Unqual!(ReturnType!G) opIndex()(size_t) { return (*_gen)(); }
+    Unqual!(EngineReturnType!G) opIndex()(size_t) { return (*_gen)(); }
 }
 
 /// ditto
@@ -158,9 +158,9 @@ struct RandomRange(G)
     if (isSaturatedRandomEngine!G)
 {
     private G* _gen;
-    private ReturnType!G _val;
+    private EngineReturnType!G _val;
     /// Largest generated value.
-    enum Unqual!(ReturnType!G) max = G.max;
+    enum Unqual!(EngineReturnType!G) max = G.max;
     /++
     Constructor.
     Stores the pointer to the `gen` engine.
@@ -169,7 +169,7 @@ struct RandomRange(G)
     /// Infinity Input Range primitives
     enum empty = false;
     /// ditto
-    Unqual!(ReturnType!G) front()() @property { return _val; }
+    Unqual!(EngineReturnType!G) front()() @property { return _val; }
     /// ditto
     void popFront()() { _val = (*_gen)(); }
 }

--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -21,6 +21,19 @@ import std.traits;
 import mir.random.engine.mersenne_twister;
 
 /++
+Like `std.traits.ReturnType!T` but it works even if
+T.opCall is a function template.
++/
+template EngineReturnType(T)
+{
+    import std.traits : ReturnType;
+    static if (is(ReturnType!T))
+        alias EngineReturnType = ReturnType!T;
+    else
+        alias EngineReturnType = typeof(T.init());
+}
+
+/++
 Test if T is a random engine.
 A type should define `enum isRandomEngine = true;` to be a random engine.
 +/
@@ -47,7 +60,7 @@ A type should define `enum isRandomEngine = true;` to be a random engine.
 template isSaturatedRandomEngine(T)
 {
     static if (isRandomEngine!T)
-        enum isSaturatedRandomEngine = T.max == ReturnType!T.max;
+        enum isSaturatedRandomEngine = T.max == EngineReturnType!T.max;
     else
         enum isSaturatedRandomEngine = false;
 }
@@ -141,7 +154,7 @@ version(mir_random_test) unittest
 {
     import std.traits;
     static assert(isSaturatedRandomEngine!Random);
-    static assert(is(ReturnType!Random == size_t));
+    static assert(is(EngineReturnType!Random == size_t));
 }
 
 version(linux)

--- a/source/mir/random/engine/pcg.d
+++ b/source/mir/random/engine/pcg.d
@@ -665,6 +665,7 @@ private alias AliasSeq(T...) = T;
                            pcg8_oneseq_once_insecure,pcg16_oneseq_once_insecure,pcg32_oneseq_once_insecure,
                            pcg64_oneseq_once_insecure))
     {
+        static assert(isSaturatedRandomEngine!RNG);
         auto gen = RNG(cast(RNG.Uint)unpredictableSeed);
         gen();
     }

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -55,7 +55,7 @@ Returns:
 T rand(T, G)(ref G gen)
     if (isSaturatedRandomEngine!G && isIntegral!T && !is(T == enum))
 {
-    alias R = ReturnType!G;
+    alias R = EngineReturnType!G;
     enum P = T.sizeof / R.sizeof;
     static if (P > 1)
     {
@@ -338,7 +338,7 @@ version(mir_random_test) unittest
 size_t randGeometric(G)(ref G gen)
     if(isSaturatedRandomEngine!G)
 {
-    alias R = ReturnType!G;
+    alias R = EngineReturnType!G;
     static if (is(R == ulong))
         alias T = size_t;
     else


### PR DESCRIPTION
std.traits.ReturnType!T doesn't work if T.opCall is a function template.
This meant that isSaturatedRandomEngine and a few other things would
not compile when given the mir.random.engine.pcg generators as template
arguments.