### PR TITLE
Prefer high bits

### DIFF
--- a/source/mir/random/engine/linear_congruential.d
+++ b/source/mir/random/engine/linear_congruential.d
@@ -18,7 +18,7 @@ struct LinearCongruentialEngine(Uint, Uint a, Uint c, Uint m)
     ///
     enum isRandomEngine = true;
 
-    /// Highest generated value ($(D modulus - 1 - bool(c == 0))).
+    /// Highest generated value (`modulus - 1 - bool(c == 0)`).
     enum Uint max = m - 1 - bool(c == 0);
 /**
 The parameters of this distribution. The random number is $(D_PARAM x
@@ -37,8 +37,8 @@ The parameters of this distribution. The random number is $(D_PARAM x
     /++
     The low bits of a linear congruential generator whose modulus is a
     power of 2 have a much shorter period than the high bits.
-    Note that for LinearCongruentialEngine, $(D modulus == 0) signifies
-    a modulus of $(D 2 ^^ Uint.sizeof) which is not representable as $(D Uint).
+    Note that for LinearCongruentialEngine, `modulus == 0` signifies
+    a modulus of `2 ^^ Uint.sizeof` which is not representable as `Uint`.
     +/
     enum bool preferHighBits = 0 == (modulus & (modulus - 1));
 
@@ -115,7 +115,7 @@ The parameters of this distribution. The random number is $(D_PARAM x
 
 /**
 Constructs a $(D_PARAM LinearCongruentialEngine) generator seeded with
-$(D x0).
+`x0`.
 Params:
     x0 = seed, must be positive if c equals to 0.
  */
@@ -179,10 +179,10 @@ Params:
 
 /**
 Define $(D_PARAM LinearCongruentialEngine) generators with well-chosen
-parameters. $(D MinstdRand0) implements Park and Miller's "minimal
+parameters. `MinstdRand0` implements Park and Miller's "minimal
 standard" $(HTTP
 wikipedia.org/wiki/Park%E2%80%93Miller_random_number_generator,
-generator) that uses 16807 for the multiplier. $(D MinstdRand)
+generator) that uses 16807 for the multiplier. `MinstdRand`
 implements a variant that has slightly better spectral behavior by
 using the multiplier 48271. Both generators are rather simplistic.
  */

--- a/source/mir/random/engine/linear_congruential.d
+++ b/source/mir/random/engine/linear_congruential.d
@@ -34,6 +34,14 @@ The parameters of this distribution. The random number is $(D_PARAM x
     static assert(m == 0 || c < m);
     static assert(m == 0 || (cast(ulong)a * (m-1) + c) % m == (c < a ? c - a + m : c - a));
 
+    /++
+    The low bits of a linear congruential generator whose modulus is a
+    power of 2 have a much shorter period than the high bits.
+    Note that for LinearCongruentialEngine, $(D modulus == 0) signifies
+    a modulus of $(D 2 ^^ Uint.sizeof) which is not representable as $(D Uint).
+    +/
+    enum bool preferHighBits = 0 == (modulus & (modulus - 1));
+
     @disable this();
     @disable this(this);
 

--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -72,6 +72,32 @@ template isSaturatedRandomEngine(T)
         enum isSaturatedRandomEngine = false;
 }
 
+/++
+Are the high bits of the engine's output known to have
+better statistical properties than the low bits of the
+output? This property is set by checking the value of
+an optional enum named `preferHighBits`. If the property
+is missing it is treated as false.
+
+This should be specified as true for:
+<ul>
+<li>linear congruential generators with power-of-2 modulus</li>
+<li>xorshift+ family</li>
+<li>xorshift* family</li>
+<li>in principle any generator whose final operation is something like
+multiplication or addition in which the high bits depend on the low bits
+but the low bits are unaffected by the high bits.</li>
+</ul>
++/
+template preferHighBits(G)
+    if (isSaturatedRandomEngine!G)
+{
+    static if (__traits(compiles, { enum bool e = G.preferHighBits; }))
+        private enum bool preferHighBits = G.preferHighBits;
+    else
+        private enum bool preferHighBits = false;
+}
+
 /**
 A "good" seed for initializing random number engines. Initializing
 with $(D_PARAM unpredictableSeed) makes engines generate different

--- a/source/mir/random/engine/xorshift.d
+++ b/source/mir/random/engine/xorshift.d
@@ -193,6 +193,15 @@ if (isIntegral!StateUInt && isIntegral!OutputUInt
     static assert(multiplier != 1 && multiplier % 2 != 0,
         typeof(this).stringof~": multiplier must be an odd number other than 1!");
 
+    /++
+    Note that when StateUInt is the same size as OutputUInt the two lowest bits
+    of this generator are
+    $(LINK2 https://en.wikipedia.org/wiki/Linear-feedback_shift_register,
+    LSFRs), and thus will fail binary rank tests. We suggest to use a sign test
+    to extract a random Boolean value, and right shifts to extract subsets of bits.
+    +/
+    enum bool preferHighBits = true;
+
   private:
     enum uint N = nbits / (StateUInt.sizeof * 8);
     enum bool usePointer = N > 3;
@@ -431,6 +440,17 @@ struct Xoroshiro128Plus
     The constructor ensures this condition is met.
     +/
     ulong[2] s = void;
+
+    /++
+    The lowest bit of this generator is an
+    $(LINK2 https://en.wikipedia.org/wiki/Linear-feedback_shift_register,
+    LSFR). The next bit is not an LFSR, but in the long run it will fail
+    binary rank tests, too. The other bits have no LFSR artifacts.
+
+    We suggest to use a sign test to extract a random Boolean value, and
+    right shifts to extract subsets of bits.
+    +/
+    enum bool preferHighBits = true;
 
     @disable this();
     @disable this(this);

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -47,29 +47,6 @@ else
 }
 
 /++
-Are the high bits of the engine's output known to have
-better statistical properties than the low bits of the
-output?
-
-True for:
-* linear congruential generators with power-of-2 modulus
-* xorshift+ family
-* xorshift* family
-* in principle any generator whose final operation is something like
-multiplication or addition in which the high bits depend on the low bits
-but the low bits are unaffected by the high bits.
-+/
-//If we make this public instead of private it should probably go in mir.random.engine.package.
-private template preferHighBits(G)
-    if (isSaturatedRandomEngine!G)
-{
-    static if (__traits(compiles, { enum bool e = G.preferHighBits; }))
-        private enum bool preferHighBits = G.preferHighBits;
-    else
-        private enum bool preferHighBits = false;
-}
-
-/++
 Params:
     gen = saturated random number generator
 Returns:

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -64,7 +64,7 @@ T rand(T, G)(ref G gen)
             (cast(R*)(&ret))[p] = gen();
         return ret;
     }
-    else static if (preferHighBits!G)
+    else static if (preferHighBits!G && P == 0)
     {
         version(LDC) pragma(inline, true);
         return cast(T) (gen() >>> ((R.sizeof - T.sizeof) * 8));

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -61,6 +61,7 @@ but the low bits are unaffected by the high bits.
 +/
 //If we make this public instead of private it should probably go in mir.random.engine.package.
 private template preferHighBits(G)
+    if (isSaturatedRandomEngine!G)
 {
     static if (__traits(compiles, { enum bool e = G.preferHighBits; }))
         private enum bool preferHighBits = G.preferHighBits;


### PR DESCRIPTION
The output of some PRNGs has output that is higher quality in the the high bits than the low bits.