### PR TITLE
Use Daniel Lemire’s fast alternative to modulo reduction

### DIFF
--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -1,0 +1,151 @@
+#!/usr/bin/env dub --build=release-nobounds --compiler=ldmd2 -v --single
+/+ dub.json: {
+    "name":"randindex_bench",
+    "dependencies": {
+        "mir-random":{"path": "../"}
+    }
+} +/
+import mir.random.engine : isSaturatedRandomEngine, EngineReturnType;
+import mir.random.engine.mersenne_twister : Mt19937, Mt19937_64;
+import mir.random.engine.pcg : pcg32_oneseq, pcg64_oneseq_once_insecure;
+import mir.random.engine.xorshift : Xoroshiro128Plus, Xorshift1024StarPhi;
+import mir.utility : min, max;
+
+import std.traits: isUnsigned, Unqual;
+
+import std.stdio, std.datetime, std.conv;
+
+/*
+Sample results on Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+
+Benchmarks for MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
+randIndexV1: 2.32964 * 10 ^^ 8 calls/s
+randIndexV2: 2.48911 * 10 ^^ 8 calls/s
+
+Benchmarks for XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
+randIndexV1: 3.73308 * 10 ^^ 8 calls/s
+randIndexV2: 3.78072 * 10 ^^ 8 calls/s
+
+Benchmarks for Xoroshiro128Plus:
+randIndexV1: 6.09292 * 10 ^^ 8 calls/s
+randIndexV2: 7.22022 * 10 ^^ 8 calls/s
+
+Benchmarks for PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
+randIndexV1: 4.40771 * 10 ^^ 8 calls/s
+randIndexV2: 3.87409 * 10 ^^ 8 calls/s <-- check this out
+
+--------
+The performance appeared to be worse for the PCG for some reason.
+I tried special-casing the algorithm for PCGs but that didn't help,
+leading me to suspect that something else was going on.
+
+To investigate I ran another test with randIndexV2 being run again
+with the label "randIndexV3".
+--------
+
+Benchmarks for MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
+randIndexV1: 2.28115 * 10 ^^ 8 calls/s
+randIndexV2: 2.41036 * 10 ^^ 8 calls/s
+randIndexV3: 2.41619 * 10 ^^ 8 calls/s
+
+Benchmarks for XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
+randIndexV1: 3.64133 * 10 ^^ 8 calls/s
+randIndexV2: 3.76471 * 10 ^^ 8 calls/s
+randIndexV3: 3.75059 * 10 ^^ 8 calls/s
+
+Benchmarks for Xoroshiro128Plus:
+randIndexV1: 6.03774 * 10 ^^ 8 calls/s
+randIndexV2: 7.08592 * 10 ^^ 8 calls/s
+randIndexV3: 7.02371 * 10 ^^ 8 calls/s
+
+Benchmarks for PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
+randIndexV1: 4.28266 * 10 ^^ 8 calls/s
+randIndexV2: 3.75587 * 10 ^^ 8 calls/s
+randIndexV3: 4.25532 * 10 ^^ 8 calls/s <--- check this out
+
+
+We can see that for PCG, it isn't that one method is faster than the
+other, but something else is going on.
+*/
+
+T randIndexV1(T, G)(ref G gen, T m)
+    if(isSaturatedRandomEngine!G && isUnsigned!T)
+{
+    assert(m, "m must be positive");
+    T ret = void;
+    T val = void;
+    do
+    {
+        //val = gen.rand!T;
+        val = cast(T) gen();
+        ret = val % m;
+    }
+    while (val - ret > -m);
+    return ret;
+}
+
+T randIndexV2(T, G)(ref G gen, T m)
+    if (isSaturatedRandomEngine!G && isUnsigned!T
+        && (T.sizeof * 2) <= (EngineReturnType!G).sizeof)
+{
+    //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
+    alias R = Unqual!(EngineReturnType!G);
+    enum rshift = (R.sizeof - T.sizeof) * 8;
+    auto randombits = gen() >>> rshift;
+    auto multiresult = randombits * m;
+    auto leftover = cast(T) multiresult;
+    if (leftover < m)
+    {
+        immutable threshold = -m % m ;
+        while (leftover < threshold)
+        {
+            randombits =  gen() >>> rshift;
+            multiresult = randombits * m;
+            leftover = cast(T) multiresult;
+        }
+    }
+    return cast(T) (multiresult >>> rshift);
+}
+
+void main(string[] args)
+{
+    import std.meta : AliasSeq;
+    uint s = 0;
+    foreach (PrngType; AliasSeq!(Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg64_oneseq_once_insecure))
+    {
+        writeln("\nBenchmarks for ", PrngType.stringof, ":");
+        enum seed = PrngType.max / 2;
+        auto gen = PrngType(seed);
+        enum ulong count = 800_000_000;
+        StopWatch sw;
+        sw.start;
+        foreach(_; 0 .. min(count / 2, 200_000_000u)) //boost CPU
+        {
+            s += gen.randIndexV1(cast(uint)100);
+            s += gen.randIndexV2(cast(uint)100);
+        }
+        sw.stop;
+        sw.reset;
+        gen.__ctor(seed);
+        sw.start;
+        foreach(_; 0..count)
+            s += gen.randIndexV1(cast(uint)100);
+        sw.stop;
+        writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        sw.reset;
+        gen.__ctor(seed);
+        sw.start;
+        foreach(_; 0..count)
+            s += gen.randIndexV2(cast(uint)100);
+        sw.stop;
+        writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        //sw.reset;
+        //gen.__ctor(seed);
+        //sw.start;
+        //foreach(_; 0..count)
+        //    s += gen.randIndexV2(cast(uint)100);
+        //sw.stop;
+        //writefln("randIndexV3: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+    }
+    writeln("Meaningless sum: ", s);
+}

--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -104,7 +104,8 @@ T randIndexV2(T, G)(ref G gen, T m)
             leftover = cast(T) multiresult;
         }
     }
-    return cast(T) (multiresult >>> rshift);
+    enum finalshift = T.sizeof * 8;//Not necessarily same as rshift. Maybe R.sizeof > T.sizeof * 2.
+    return cast(T) (multiresult >>> finalshift);
 }
 
 void main(string[] args)

--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -5,6 +5,7 @@
         "mir-random":{"path": "../"}
     }
 } +/
+import mir.random : rand, randIndex;
 import mir.random.engine : isSaturatedRandomEngine, EngineReturnType;
 import mir.random.engine.mersenne_twister : Mt19937, Mt19937_64;
 import mir.random.engine.pcg : pcg32_oneseq, pcg64_oneseq_once_insecure;
@@ -19,65 +20,38 @@ import std.stdio, std.datetime, std.conv;
 Sample results on Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
 
 Benchmarks for MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
-randIndexV1: 2.32964 * 10 ^^ 8 calls/s
-randIndexV2: 2.48911 * 10 ^^ 8 calls/s
+randIndexV1: 1.34454 * 10 ^^ 8 calls/s
+randIndexV2: 1.82066 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 2.34949 * 10 ^^ 8 calls/s
 
 Benchmarks for XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
-randIndexV1: 3.73308 * 10 ^^ 8 calls/s
-randIndexV2: 3.78072 * 10 ^^ 8 calls/s
+randIndexV1: 2.26436 * 10 ^^ 8 calls/s
+randIndexV2: 3.0349 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 3.83693 * 10 ^^ 8 calls/s
 
 Benchmarks for Xoroshiro128Plus:
-randIndexV1: 6.09292 * 10 ^^ 8 calls/s
-randIndexV2: 7.22022 * 10 ^^ 8 calls/s
+randIndexV1: 2.60671 * 10 ^^ 8 calls/s
+randIndexV2: 3.848 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 7.06714 * 10 ^^ 8 calls/s
 
 Benchmarks for PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
-randIndexV1: 4.40771 * 10 ^^ 8 calls/s
-randIndexV2: 3.87409 * 10 ^^ 8 calls/s <-- check this out
-
---------
-The performance appeared to be worse for the PCG for some reason.
-I tried special-casing the algorithm for PCGs but that didn't help,
-leading me to suspect that something else was going on.
-
-To investigate I ran another test with randIndexV2 being run again
-with the label "randIndexV3".
---------
-
-Benchmarks for MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
-randIndexV1: 2.28115 * 10 ^^ 8 calls/s
-randIndexV2: 2.41036 * 10 ^^ 8 calls/s
-randIndexV3: 2.41619 * 10 ^^ 8 calls/s
-
-Benchmarks for XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
-randIndexV1: 3.64133 * 10 ^^ 8 calls/s
-randIndexV2: 3.76471 * 10 ^^ 8 calls/s
-randIndexV3: 3.75059 * 10 ^^ 8 calls/s
-
-Benchmarks for Xoroshiro128Plus:
-randIndexV1: 6.03774 * 10 ^^ 8 calls/s
-randIndexV2: 7.08592 * 10 ^^ 8 calls/s
-randIndexV3: 7.02371 * 10 ^^ 8 calls/s
-
-Benchmarks for PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
-randIndexV1: 4.28266 * 10 ^^ 8 calls/s
-randIndexV2: 3.75587 * 10 ^^ 8 calls/s
-randIndexV3: 4.25532 * 10 ^^ 8 calls/s <--- check this out
-
-
-We can see that for PCG, it isn't that one method is faster than the
-other, but something else is going on.
+randIndexV1: 1.45243 * 10 ^^ 8 calls/s
+randIndexV2: 2.47755 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 4.18848 * 10 ^^ 8 calls/s
 */
 
 T randIndexV1(T, G)(ref G gen, T m)
     if(isSaturatedRandomEngine!G && isUnsigned!T)
 {
+    pragma(inline, false);//Try to prevent LDC from doing anything clever with the modulus.
+    static assert(is(T == uint), "During this test, if !is(T == uint) there is a mistake!");
+
     assert(m, "m must be positive");
     T ret = void;
     T val = void;
     do
     {
-        //val = gen.rand!T;
-        val = cast(T) gen();
+        val = gen.rand!T;
         ret = val % m;
     }
     while (val - ret > -m);
@@ -88,23 +62,26 @@ T randIndexV2(T, G)(ref G gen, T m)
     if (isSaturatedRandomEngine!G && isUnsigned!T
         && (T.sizeof * 2) <= (EngineReturnType!G).sizeof)
 {
+    pragma(inline, false);//Try to prevent LDC from doing anything clever with the modulus.
+    static assert(is(T == uint), "During this test, if !is(T == uint) there is a mistake!");
+
     //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
+    import mir.ndslice.internal: _expect;
     alias R = Unqual!(EngineReturnType!G);
-    enum rshift = (R.sizeof - T.sizeof) * 8;
-    auto randombits = gen() >>> rshift;
-    auto multiresult = randombits * m;
-    auto leftover = cast(T) multiresult;
+    R randombits = cast(R) gen.rand!T;
+    R multiresult = randombits * m;
+    T leftover = cast(T) multiresult;
     if (leftover < m)
     {
         immutable threshold = -m % m ;
-        while (leftover < threshold)
+        while (_expect(leftover < threshold, false))
         {
-            randombits =  gen() >>> rshift;
+            randombits =  cast(R) gen.rand!T;
             multiresult = randombits * m;
             leftover = cast(T) multiresult;
         }
     }
-    enum finalshift = T.sizeof * 8;//Not necessarily same as rshift. Maybe R.sizeof > T.sizeof * 2.
+    enum finalshift = T.sizeof * 8;
     return cast(T) (multiresult >>> finalshift);
 }
 
@@ -118,35 +95,73 @@ void main(string[] args)
         enum seed = PrngType.max / 2;
         auto gen = PrngType(seed);
         enum ulong count = 800_000_000;
+        enum uint modulus_min = 6;
+        enum uint modulus_max = 6 + 100;
+        static assert(count % (modulus_max - modulus_min) == 0);
+        enum outer_loop_iterations = count / (modulus_max - modulus_min);
+        enum warmup_outer_loop_iterations = min(outer_loop_iterations / 2, 2_000_000u);
+
         StopWatch sw;
         sw.start;
-        foreach(_; 0 .. min(count / 2, 200_000_000u)) //boost CPU
+        foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
         {
-            s += gen.randIndexV1(cast(uint)100);
-            s += gen.randIndexV2(cast(uint)100);
+            foreach (m; modulus_min .. modulus_max)
+            {
+                s += gen.randIndexV1(m);
+                s += gen.randIndexV2(m);
+            }
         }
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
         sw.start;
-        foreach(_; 0..count)
-            s += gen.randIndexV1(cast(uint)100);
+        foreach(_; 0..outer_loop_iterations)
+        {
+            foreach (m; modulus_min .. modulus_max)
+                s += gen.randIndexV1(m);
+        }
         sw.stop;
         writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        sw.start;
+        foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
+        {
+            foreach (m; modulus_min ..modulus_max)
+            {
+                s += gen.randIndexV1(m);
+                s += gen.randIndexV2(m);
+            }
+        }
+        sw.stop;
         sw.reset;
         gen.__ctor(seed);
         sw.start;
-        foreach(_; 0..count)
-            s += gen.randIndexV2(cast(uint)100);
+        foreach(_; 0..outer_loop_iterations)
+        {
+            foreach (m; modulus_min .. modulus_max)
+                s += gen.randIndexV2(m);
+        }
         sw.stop;
         writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
-        //sw.reset;
-        //gen.__ctor(seed);
-        //sw.start;
-        //foreach(_; 0..count)
-        //    s += gen.randIndexV2(cast(uint)100);
-        //sw.stop;
-        //writefln("randIndexV3: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        sw.start;
+        foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
+        {
+            foreach (m; modulus_min ..modulus_max)
+            {
+                s += gen.randIndexV1(m);
+                s += gen.randIndex(m);
+            }
+        }
+        sw.stop;
+        sw.reset;
+        gen.__ctor(seed);
+        sw.start;
+        foreach(_; 0..outer_loop_iterations)
+        {
+            foreach (m; modulus_min .. modulus_max)
+                s += gen.randIndex(m);
+        }
+        sw.stop;
+        writefln("new mir.random.randIndex (potential inlining shenanigans): %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
     }
     writeln("Meaningless sum: ", s);
 }

--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -214,7 +214,6 @@ T randIndexV2(T, G)(ref G gen, T m)
 void main(string[] args)
 {
     import std.meta : AliasSeq;
-    uint s = 0;
 
     foreach (PrngType; AliasSeq!(Mt19937, Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg32_oneseq, pcg64_oneseq_once_insecure))
     {
@@ -227,6 +226,7 @@ void main(string[] args)
         static assert(count % (modulus_max - modulus_min) == 0);
         enum outer_loop_iterations = count / (modulus_max - modulus_min);
         enum warmup_outer_loop_iterations = min(outer_loop_iterations / 2, 2_000_000u);
+        ulong s = 0;
 
         StopWatch sw;
         sw.start;
@@ -241,6 +241,7 @@ void main(string[] args)
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
+        s = 0;
         sw.start;
         foreach(_; 0..outer_loop_iterations)
         {
@@ -248,7 +249,7 @@ void main(string[] args)
                 s += gen.randIndexV1!ulong(m);
         }
         sw.stop;
-        writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        writefln("randIndexV1: %s * 10 ^^ 8 calls/s; sum = %d", double(count) / sw.peek.msecs / 100_000, s);
         sw.start;
         foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
         {
@@ -261,6 +262,7 @@ void main(string[] args)
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
+        s = 0;
         sw.start;
         foreach(_; 0..outer_loop_iterations)
         {
@@ -268,7 +270,7 @@ void main(string[] args)
                 s += gen.randIndexV2!ulong(m);
         }
         sw.stop;
-        writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        writefln("randIndexV2: %s * 10 ^^ 8 calls/s; sum = %d", double(count) / sw.peek.msecs / 100_000, s);
     }
 
     foreach (PrngType; AliasSeq!(Mt19937, Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg32_oneseq, pcg64_oneseq_once_insecure))
@@ -282,6 +284,7 @@ void main(string[] args)
         static assert(count % (modulus_max - modulus_min) == 0);
         enum outer_loop_iterations = count / (modulus_max - modulus_min);
         enum warmup_outer_loop_iterations = min(outer_loop_iterations / 2, 2_000_000u);
+        ulong s = 0;
 
         StopWatch sw;
         sw.start;
@@ -296,14 +299,17 @@ void main(string[] args)
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
+        s = 0;
         sw.start;
         foreach(_; 0..outer_loop_iterations)
         {
+            uint s1 = 0;
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndexV1!uint(m);
+                s1 += gen.randIndexV1!uint(m);
+            s += s1;
         }
         sw.stop;
-        writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        writefln("randIndexV1: %s * 10 ^^ 8 calls/s; sum = %d", double(count) / sw.peek.msecs / 100_000, s);
         sw.start;
         foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
         {
@@ -316,14 +322,17 @@ void main(string[] args)
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
+        s = 0;
         sw.start;
         foreach(_; 0..outer_loop_iterations)
         {
+            uint s1 = 0;
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndexV2!uint(m);
+                s1 += gen.randIndexV2!uint(m);
+            s += s1;
         }
         sw.stop;
-        writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        writefln("randIndexV2: %s * 10 ^^ 8 calls/s; sum = %d", double(count) / sw.peek.msecs / 100_000, s);
         sw.start;
         foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
         {
@@ -336,14 +345,16 @@ void main(string[] args)
         sw.stop;
         sw.reset;
         gen.__ctor(seed);
+        s = 0;
         sw.start;
         foreach(_; 0..outer_loop_iterations)
         {
+            uint s1 = 0;
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndex!uint(m);
+                s1 += gen.randIndex!uint(m);
+            s += s1;
         }
         sw.stop;
-        writefln("new mir.random.randIndex (potential inlining shenanigans): %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        writefln("new mir.random.randIndex (potential inlining shenanigans): %s * 10 ^^ 8 calls/s; sum = %d", double(count) / sw.peek.msecs / 100_000, s);
     }
-    writeln("Meaningless sum: ", s);
 }

--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -19,32 +19,73 @@ import std.stdio, std.datetime, std.conv;
 /*
 Sample results on Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
 
-Benchmarks for MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
-randIndexV1: 1.34454 * 10 ^^ 8 calls/s
-randIndexV2: 1.82066 * 10 ^^ 8 calls/s
-new mir.random.randIndex (potential inlining shenanigans): 2.34949 * 10 ^^ 8 calls/s
+//
+// GENERATING ULONG BENCHMARKS
+//
 
-Benchmarks for XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
-randIndexV1: 2.26436 * 10 ^^ 8 calls/s
-randIndexV2: 3.0349 * 10 ^^ 8 calls/s
-new mir.random.randIndex (potential inlining shenanigans): 3.83693 * 10 ^^ 8 calls/s
+Benchmarks for generating ulong from MersenneTwisterEngine!(uint, 32LU, 624LU, 397LU, 31LU, 2567483615u, 11LU, 4294967295u, 7LU, 2636928640u, 15LU, 4022730752u, 18LU, 1812433253u):
+randIndexV1: 0.634417 * 10 ^^ 8 calls/s
+randIndexV2: 1.05277 * 10 ^^ 8 calls/s
 
-Benchmarks for Xoroshiro128Plus:
-randIndexV1: 2.60671 * 10 ^^ 8 calls/s
-randIndexV2: 3.848 * 10 ^^ 8 calls/s
-new mir.random.randIndex (potential inlining shenanigans): 7.06714 * 10 ^^ 8 calls/s
+Benchmarks for generating ulong from MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
+randIndexV1: 0.766284 * 10 ^^ 8 calls/s
+randIndexV2: 1.72228 * 10 ^^ 8 calls/s
 
-Benchmarks for PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
-randIndexV1: 1.45243 * 10 ^^ 8 calls/s
-randIndexV2: 2.47755 * 10 ^^ 8 calls/s
-new mir.random.randIndex (potential inlining shenanigans): 4.18848 * 10 ^^ 8 calls/s
+Benchmarks for generating ulong from XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
+randIndexV1: 1.05056 * 10 ^^ 8 calls/s
+randIndexV2: 2.71278 * 10 ^^ 8 calls/s
+
+Benchmarks for generating ulong from Xoroshiro128Plus:
+randIndexV1: 1.0661 * 10 ^^ 8 calls/s
+randIndexV2: 3.69857 * 10 ^^ 8 calls/s
+
+Benchmarks for generating ulong from PermutedCongruentialEngine!(xsh_rr, cast(stream_t)2, true):
+randIndexV1: 0.722413 * 10 ^^ 8 calls/s
+randIndexV2: 1.44875 * 10 ^^ 8 calls/s
+
+Benchmarks for generating ulong from PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
+randIndexV1: 0.861141 * 10 ^^ 8 calls/s
+randIndexV2: 2.30083 * 10 ^^ 8 calls/s
+
+//
+// GENERATING UINT BENCHMARKS
+//
+
+Benchmarks for generating uint from MersenneTwisterEngine!(uint, 32LU, 624LU, 397LU, 31LU, 2567483615u, 11LU, 4294967295u, 7LU, 2636928640u, 15LU, 4022730752u, 18LU, 1812433253u):
+randIndexV1: 1.3836 * 10 ^^ 8 calls/s
+randIndexV2: 2.00803 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 2.42571 * 10 ^^ 8 calls/s
+
+Benchmarks for generating uint from MersenneTwisterEngine!(ulong, 64LU, 312LU, 156LU, 31LU, 13043109905998158313LU, 29LU, 6148914691236517205LU, 17LU, 8202884508482404352LU, 37LU, 18444473444759240704LU, 43LU, 6364136223846793005LU):
+randIndexV1: 1.29997 * 10 ^^ 8 calls/s
+randIndexV2: 1.8269 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 2.30216 * 10 ^^ 8 calls/s
+
+Benchmarks for generating uint from XorshiftStarEngine!(ulong, 1024u, 31u, 11u, 30u, 11400714819323198483LU, ulong):
+randIndexV1: 2.28637 * 10 ^^ 8 calls/s
+randIndexV2: 3.16081 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 3.70199 * 10 ^^ 8 calls/s
+
+Benchmarks for generating uint from Xoroshiro128Plus:
+randIndexV1: 2.56082 * 10 ^^ 8 calls/s
+randIndexV2: 4.37158 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 6.9869 * 10 ^^ 8 calls/s
+
+Benchmarks for generating uint from PermutedCongruentialEngine!(xsh_rr, cast(stream_t)2, true):
+randIndexV1: 1.50404 * 10 ^^ 8 calls/s
+randIndexV2: 2.32221 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 3.86847 * 10 ^^ 8 calls/s
+
+Benchmarks for generating uint from PermutedCongruentialEngine!(rxs_m_xs_forward, cast(stream_t)2, true):
+randIndexV1: 1.47411 * 10 ^^ 8 calls/s
+randIndexV2: 2.49377 * 10 ^^ 8 calls/s
+new mir.random.randIndex (potential inlining shenanigans): 4.24178 * 10 ^^ 8 calls/s
 */
 
 T randIndexV1(T, G)(ref G gen, T m)
     if(isSaturatedRandomEngine!G && isUnsigned!T)
 {
     pragma(inline, false);//Try to prevent LDC from doing anything clever with the modulus.
-    static assert(is(T == uint), "During this test, if !is(T == uint) there is a mistake!");
 
     assert(m, "m must be positive");
     T ret = void;
@@ -58,40 +99,181 @@ T randIndexV1(T, G)(ref G gen, T m)
     return ret;
 }
 
-T randIndexV2(T, G)(ref G gen, T m)
-    if (isSaturatedRandomEngine!G && isUnsigned!T
-        && (T.sizeof * 2) <= (EngineReturnType!G).sizeof)
+static import core.simd;
+version(LDC) static if (is(core.simd.Vector!(ulong[2])))
 {
-    pragma(inline, false);//Try to prevent LDC from doing anything clever with the modulus.
-    static assert(is(T == uint), "During this test, if !is(T == uint) there is a mistake!");
-
-    //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
-    import mir.ndslice.internal: _expect;
-    alias R = Unqual!(EngineReturnType!G);
-    R randombits = cast(R) gen.rand!T;
-    R multiresult = randombits * m;
-    T leftover = cast(T) multiresult;
-    if (_expect(leftover < m, false))
+    private @nogc nothrow pure @safe
     {
-        immutable threshold = -m % m ;
-        while (leftover < threshold)
+        pragma(LDC_inline_ir) R inlineIR(string s, R, P...)(P);
+
+        pragma(inline, true)
+        core.simd.ulong2 mul_128(ulong a, ulong b)
         {
-            randombits =  cast(R) gen.rand!T;
-            multiresult = randombits * m;
-            leftover = cast(T) multiresult;
+            return inlineIR!(`
+                %a = zext i64 %0 to i128
+                %b = zext i64 %1 to i128
+                %ra = mul i128 %a, %b
+                %rb = bitcast i128 %ra to <2 x i64>
+                ret <2 x i64> %rb`, core.simd.ulong2)(a, b);
         }
     }
-    enum finalshift = T.sizeof * 8;
-    return cast(T) (multiresult >>> finalshift);
+}
+
+T randIndexV2(T, G)(ref G gen, T m)
+    if(isSaturatedRandomEngine!G && isUnsigned!T)
+{
+    pragma(inline, false);//Try to prevent LDC from doing anything clever with the modulus.
+    static if (EngineReturnType!G.sizeof >= T.sizeof * 2)
+        alias MaybeR = EngineReturnType!G;
+    else static if (uint.sizeof >= T.sizeof * 2)
+        alias MaybeR = uint;
+    else static if (ulong.sizeof >= T.sizeof * 2)
+        alias MaybeR = ulong;
+    else static if (is(ucent) && __traits(compiles, {static assert(ucent.sizeof >= T.sizeof * 2);}))
+        mixin ("MaybeR = ucent;");
+    else
+        alias MaybeR = void;
+
+    static if (!is(MaybeR == void))
+    {
+        if (!__ctfe)
+        {
+            alias R = MaybeR;
+            static assert(R.sizeof >= T.sizeof * 2);
+            import mir.ndslice.internal: _expect;
+            //Use Daniel Lemire's fast alternative to modulo reduction:
+            //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
+            R randombits = cast(R) gen.rand!T;
+            R multiresult = randombits * m;
+            T leftover = cast(T) multiresult;
+            if (_expect(leftover < m, false))
+            {
+                immutable threshold = -m % m ;
+                while (leftover < threshold)
+                {
+                    randombits =  cast(R) gen.rand!T;
+                    multiresult = randombits * m;
+                    leftover = cast(T) multiresult;
+                }
+            }
+            enum finalshift = T.sizeof * 8;
+            return cast(T) (multiresult >>> finalshift);
+        }
+    }
+    else version(LDC)
+    {
+        static if (T.sizeof == ulong.sizeof && is(core.simd.Vector!(ulong[2])))
+        {
+            if (!__ctfe)
+            {
+                import mir.ndslice.internal: _expect;
+
+                version (LittleEndian)
+                    static struct S1 { ulong leftover, highbits; }
+                else version (BigEndian)
+                    static struct S1 { ulong highbits, leftover; }
+                else
+                    static assert(0, "Neither LittleEndian nor BigEndian!");
+
+                static union U1
+                {
+                    core.simd.ulong2 v;
+                    S1 s;
+                }
+                static assert(S1.sizeof == core.simd.ulong2.sizeof);
+
+                //Use Daniel Lemire's fast alternative to modulo reduction:
+                //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
+                U1 u = void;
+                u.v = mul_128(gen.rand!ulong, cast(ulong)m);
+                if (_expect(u.s.leftover < m, false))
+                {
+                    immutable T threshold = -m % m;
+                    while (u.s.leftover < threshold)
+                    {
+                        u.v = mul_128(gen.rand!ulong, cast(ulong)m);
+                    }
+                }
+                return u.s.highbits;
+            }
+        }
+    }
+    //Default algorithm.
+    assert(m, "m must be positive");
+    T ret = void;
+    T val = void;
+    do
+    {
+        val = gen.rand!T;
+        ret = val % m;
+    }
+    while (val - ret > -m);
+    return ret;
 }
 
 void main(string[] args)
 {
     import std.meta : AliasSeq;
     uint s = 0;
-    foreach (PrngType; AliasSeq!(Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg64_oneseq_once_insecure))
+
+    foreach (PrngType; AliasSeq!(Mt19937, Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg32_oneseq, pcg64_oneseq_once_insecure))
     {
-        writeln("\nBenchmarks for ", PrngType.stringof, ":");
+        writeln("\nBenchmarks for generating ulong from ", PrngType.stringof, ":");
+        enum seed = PrngType.max / 2;
+        auto gen = PrngType(seed);
+        enum ulong count = 800_000_000;
+        enum ulong modulus_min = 6;
+        enum ulong modulus_max = 6 + 100;
+        static assert(count % (modulus_max - modulus_min) == 0);
+        enum outer_loop_iterations = count / (modulus_max - modulus_min);
+        enum warmup_outer_loop_iterations = min(outer_loop_iterations / 2, 2_000_000u);
+
+        StopWatch sw;
+        sw.start;
+        foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
+        {
+            foreach (m; modulus_min ..modulus_max)
+            {
+                s += gen.randIndexV1!ulong(m);
+                s += gen.randIndexV2!ulong(m);
+            }
+        }
+        sw.stop;
+        sw.reset;
+        gen.__ctor(seed);
+        sw.start;
+        foreach(_; 0..outer_loop_iterations)
+        {
+            foreach (m; modulus_min .. modulus_max)
+                s += gen.randIndexV1!ulong(m);
+        }
+        sw.stop;
+        writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+        sw.start;
+        foreach(_; 0 .. warmup_outer_loop_iterations) //boost CPU
+        {
+            foreach (m; modulus_min ..modulus_max)
+            {
+                s += gen.randIndexV1!ulong(m);
+                s += gen.randIndexV2!ulong(m);
+            }
+        }
+        sw.stop;
+        sw.reset;
+        gen.__ctor(seed);
+        sw.start;
+        foreach(_; 0..outer_loop_iterations)
+        {
+            foreach (m; modulus_min .. modulus_max)
+                s += gen.randIndexV2!ulong(m);
+        }
+        sw.stop;
+        writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
+    }
+
+    foreach (PrngType; AliasSeq!(Mt19937, Mt19937_64, Xorshift1024StarPhi, Xoroshiro128Plus, pcg32_oneseq, pcg64_oneseq_once_insecure))
+    {
+        writeln("\nBenchmarks for generating uint from ", PrngType.stringof, ":");
         enum seed = PrngType.max / 2;
         auto gen = PrngType(seed);
         enum ulong count = 800_000_000;
@@ -107,8 +289,8 @@ void main(string[] args)
         {
             foreach (m; modulus_min .. modulus_max)
             {
-                s += gen.randIndexV1(m);
-                s += gen.randIndexV2(m);
+                s += gen.randIndexV1!uint(m);
+                s += gen.randIndexV2!uint(m);
             }
         }
         sw.stop;
@@ -118,7 +300,7 @@ void main(string[] args)
         foreach(_; 0..outer_loop_iterations)
         {
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndexV1(m);
+                s += gen.randIndexV1!uint(m);
         }
         sw.stop;
         writefln("randIndexV1: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
@@ -127,8 +309,8 @@ void main(string[] args)
         {
             foreach (m; modulus_min ..modulus_max)
             {
-                s += gen.randIndexV1(m);
-                s += gen.randIndexV2(m);
+                s += gen.randIndexV1!uint(m);
+                s += gen.randIndexV2!uint(m);
             }
         }
         sw.stop;
@@ -138,7 +320,7 @@ void main(string[] args)
         foreach(_; 0..outer_loop_iterations)
         {
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndexV2(m);
+                s += gen.randIndexV2!uint(m);
         }
         sw.stop;
         writefln("randIndexV2: %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);
@@ -147,8 +329,8 @@ void main(string[] args)
         {
             foreach (m; modulus_min ..modulus_max)
             {
-                s += gen.randIndexV1(m);
-                s += gen.randIndex(m);
+                s += gen.randIndexV1!uint(m);
+                s += gen.randIndex!uint(m);
             }
         }
         sw.stop;
@@ -158,7 +340,7 @@ void main(string[] args)
         foreach(_; 0..outer_loop_iterations)
         {
             foreach (m; modulus_min .. modulus_max)
-                s += gen.randIndex(m);
+                s += gen.randIndex!uint(m);
         }
         sw.stop;
         writefln("new mir.random.randIndex (potential inlining shenanigans): %s * 10 ^^ 8 calls/s", double(count) / sw.peek.msecs / 100_000);

--- a/bench/randindex_bench.d
+++ b/bench/randindex_bench.d
@@ -71,10 +71,10 @@ T randIndexV2(T, G)(ref G gen, T m)
     R randombits = cast(R) gen.rand!T;
     R multiresult = randombits * m;
     T leftover = cast(T) multiresult;
-    if (leftover < m)
+    if (_expect(leftover < m, false))
     {
         immutable threshold = -m % m ;
-        while (_expect(leftover < threshold, false))
+        while (leftover < threshold)
         {
             randombits =  cast(R) gen.rand!T;
             multiresult = randombits * m;

--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
 	"copyright": "Copyright © 2016-2017, Ilya Yaroshenko, see also copyright per file",
 	"license": "BSL-1.0 (default), Apache License, Version 2.0 for (for PCG)",
 	"dependencies": {
-		"mir-algorithm": "~>0.7.0-alpha5"
+		"mir-algorithm": "~>0.7.0-alpha7"
 	},
 	"buildTypes": {
 		"unittest": {

--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
 	"copyright": "Copyright © 2016-2017, Ilya Yaroshenko, see also copyright per file",
 	"license": "BSL-1.0 (default), Apache License, Version 2.0 for (for PCG)",
 	"dependencies": {
-		"mir-algorithm": "~>0.6.0"
+		"mir-algorithm": "~>0.7.0-alpha5"
 	},
 	"buildTypes": {
 		"unittest": {

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -344,10 +344,10 @@ T randIndex(T, G)(ref G gen, T m)
                     R randombits = cast(R) gen.rand!T;
                     R multiresult = randombits * m;
                     T leftover = cast(T) multiresult;
-                    if (leftover < m)
+                    if (_expect(leftover < m, false))
                     {
                         immutable threshold = -m % m ;
-                        while (_expect(leftover < threshold, false))
+                        while (leftover < threshold)
                         {
                             randombits =  cast(R) gen.rand!T;
                             multiresult = randombits * m;

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -456,12 +456,10 @@ T randIndex(T, G)(ref G gen, T m)
     uint s = gen.randIndex!uint(100);
 
     //Test CTFE of randIndex!uint from generator with return type ulong. 
-    uint e = () {
+    enum uint e = () {
             auto g = Xoroshiro128Plus(1);
             return g.randIndex!uint(100);
         }();
-
-    assert(s == e);
 }
 
 @nogc nothrow pure @safe version(mir_random_test) unittest

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -321,7 +321,7 @@ version(mir_random_test) unittest
     assert(-double.min_normal < x && x < double.min_normal);
 }
 
-version(LDC) static if (is(core.simd.Vector!(ulong[2])))
+version(LDC) static if (is(core.simd.Vector!(ulong[2])) && !is(ucent))
 {
     private @nogc nothrow pure @safe
     {
@@ -336,6 +336,18 @@ version(LDC) static if (is(core.simd.Vector!(ulong[2])))
                 %ra = mul i128 %a, %b
                 %rb = bitcast i128 %ra to <2 x i64>
                 ret <2 x i64> %rb`, core.simd.ulong2)(a, b);
+        }
+
+        static union mul_128_u
+        {
+            core.simd.ulong2 v;
+
+            version (LittleEndian)
+                struct { ulong leftover, highbits; }
+            else version (BigEndian)
+                struct { ulong highbits, leftover; }
+            else
+                static assert(0, "Neither LittleEndian nor BigEndian!");
         }
     }
 }
@@ -394,34 +406,19 @@ T randIndex(T, G)(ref G gen, T m)
             if (!__ctfe)
             {
                 import mir.ndslice.internal: _expect;
-
-                version (LittleEndian)
-                    static struct S1 { ulong leftover, highbits; }
-                else version (BigEndian)
-                    static struct S1 { ulong highbits, leftover; }
-                else
-                    static assert(0, "Neither LittleEndian nor BigEndian!");
-
-                static union U1
-                {
-                    core.simd.ulong2 v;
-                    S1 s;
-                }
-                static assert(S1.sizeof == core.simd.ulong2.sizeof);
-
                 //Use Daniel Lemire's fast alternative to modulo reduction:
                 //https://lemire.me/blog/2016/06/30/fast-random-shuffling/
-                U1 u = void;
+                mul_128_u u = void;
                 u.v = mul_128(gen.rand!ulong, cast(ulong)m);
-                if (_expect(u.s.leftover < m, false))
+                if (_expect(u.leftover < m, false))
                 {
                     immutable T threshold = -m % m;
-                    while (u.s.leftover < threshold)
+                    while (u.leftover < threshold)
                     {
                         u.v = mul_128(gen.rand!ulong, cast(ulong)m);
                     }
                 }
-                return u.s.highbits;
+                return u.highbits;
             }
         }
     }


### PR DESCRIPTION
[Full explanation on Daniel Lemire's blog.](https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/) [Another entry covers bias correction when using this method.](https://lemire.me/blog/2016/06/30/fast-random-shuffling/)

If our `gen()` produces `ulong` and we want to convert this to a `uint` in range `0 .. m`, instead of
```
(cast(uint) gen()) % m
```
we can do:
```
cast(uint) (((gen() >>> 32) * m) >>> 32)
```
which replaces a modulo operation with a multiplication and some shifts.

I put a benchmark for this at [bench/randindex_bench.d](https://github.com/n8sh/mir-random/blob/9fe19f33766cdce7baa00b3b024d5c0d2e5bd29b/bench/randindex_bench.d). The performance gain was minor, but the result persisted when running the benchmark repeatedly.

----
**EDIT:**
As @9il points out below, the original benchmark was flawed due to the compiler being too clever and optimizing for a constant modulus. After working to prevent this, the speed advantage of the new version [increased](https://github.com/n8sh/mir-random/blob/2e90600bd905d71653a0735058b296fbe1061222/bench/randindex_bench.d).