### PR TITLE
`@safe unittest` for every function in mir.random.algorithm

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
 	"license": "BSL-1.0 (default), Apache License, Version 2.0 for (for PCG)",
 	"dependencies": {
 		"mir-linux-kernel": "~>1.0.0",
-		"mir-algorithm": "~>0.7.0-alpha7"
+		"mir-algorithm": "~>0.7.0-alpha8"
 	},
 	"buildTypes": {
 		"unittest": {


### PR DESCRIPTION
Includes changes required for `unittest`s to pass.
Requires mir.random.package to have been made `@safe`
Part of ongoing effort https://github.com/libmir/mir-random/issues/40