### PR TITLE
Add compatibility with Phobos random interface to PCG and xoroshiro128+

### DIFF
--- a/source/mir/random/engine/pcg.d
+++ b/source/mir/random/engine/pcg.d
@@ -223,11 +223,7 @@ public:
         state = cast(Uint)(acc_mult*state + acc_plus);
     }
 
-    static if (!output_previous)
-    {
-        //InputRange mode is only low-cost when output_previous == true.
-    }
-    else
+    static if (output_previous)
     {
         /++
         Compatibility with Phobos library methods. Presents this RNG as an
@@ -259,12 +255,12 @@ public:
     //Test that the default generators (all having output_previous==true)
     //can be used as Phobos-style randoms.
     import std.meta: AliasSeq;
-    import std.random: isSeedable, isUniformRNG;
+    import std.random: isSeedable, isPhobosUniformRNG = isUniformRNG;
     foreach(RNG; AliasSeq!(pcg32, pcg32_oneseq, pcg32_fast,
                            pcg32_once_insecure, pcg32_oneseq_once_insecure,
                            pcg64_once_insecure, pcg64_oneseq_once_insecure))
     {
-        static assert(isUniformRNG!(RNG, typeof(RNG.max)));
+        static assert(isPhobosUniformRNG!(RNG, typeof(RNG.max)));
         static assert(isSeedable!(RNG, RNG.Uint));
         auto gen1 = RNG(1);
         auto gen2 = RNG(2);
@@ -278,7 +274,7 @@ public:
 
     foreach(RNG; AliasSeq!(pcg32_unique))
     {
-        static assert(isUniformRNG!(RNG, typeof(RNG.max)));
+        static assert(isPhobosUniformRNG!(RNG, typeof(RNG.max)));
         static assert(isSeedable!(RNG, RNG.Uint));
     }
 }

--- a/source/mir/random/engine/pcg.d
+++ b/source/mir/random/engine/pcg.d
@@ -222,6 +222,65 @@ public:
         }
         state = cast(Uint)(acc_mult*state + acc_plus);
     }
+
+    static if (!output_previous)
+    {
+        //InputRange mode is only low-cost when output_previous == true.
+    }
+    else
+    {
+        /++
+        Compatibility with Phobos library methods. Presents this RNG as an
+        InputRange. Only available if `output_previous == true`.
+
+        The reason that this is enabled when `output_previous == true` is because
+        `front` can be implemented without additional cost.
+
+        This class disables the default copy constructor and so will only work with
+        Phobos functions that "do the right thing" and take RNGs by reference and
+        do not accidentally make implicit copies.
+        +/
+        enum bool isUniformRandom = true;
+        /// ditto
+        enum ReturnType!output min = (ReturnType!output).min;
+        /// ditto
+        enum bool empty = false;
+        /// ditto
+        @property ReturnType!output front()() const { return output(state); }
+        /// ditto
+        void popFront()() { state = bump(state); }
+        /// ditto
+        void seed()(Uint seed) { this.__ctor(seed); }
+    }
+}
+
+@nogc nothrow pure @safe version(mir_random_test) unittest
+{
+    //Test that the default generators (all having output_previous==true)
+    //can be used as Phobos-style randoms.
+    import std.meta: AliasSeq;
+    import std.random: isSeedable, isUniformRNG;
+    foreach(RNG; AliasSeq!(pcg32, pcg32_oneseq, pcg32_fast,
+                           pcg32_once_insecure, pcg32_oneseq_once_insecure,
+                           pcg64_once_insecure, pcg64_oneseq_once_insecure))
+    {
+        static assert(isUniformRNG!(RNG, typeof(RNG.max)));
+        static assert(isSeedable!(RNG, RNG.Uint));
+        auto gen1 = RNG(1);
+        auto gen2 = RNG(2);
+        gen2.seed(1);
+        assert(gen1 == gen2);
+        immutable a = gen1.front;
+        gen1.popFront();
+        assert(a == gen2());
+        assert(gen1.front == gen2());
+    }
+
+    foreach(RNG; AliasSeq!(pcg32_unique))
+    {
+        static assert(isUniformRNG!(RNG, typeof(RNG.max)));
+        static assert(isSeedable!(RNG, RNG.Uint));
+    }
 }
 
 // Default multiplier to use for the LCG portion of the PCG

--- a/source/mir/random/engine/xorshift.d
+++ b/source/mir/random/engine/xorshift.d
@@ -512,6 +512,29 @@ struct Xoroshiro128Plus
         s[0] = s0;
         s[1] = s1;
     }
+
+
+    /++
+    Compatibility with Phobos random interface. Presents this RNG as an InputRange.
+
+    This class disables the default copy constructor and so will only work with
+    Phobos functions that "do the right thing" and take RNGs by reference and
+    do not accidentally make implicit copies.
+    +/
+    enum bool isUniformRandom = true;
+    /// ditto
+    enum typeof(this.max) min = typeof(this.max).min;
+    /// ditto
+    enum bool empty = false;
+    /// ditto
+    @property ulong front()() const { return s[0] + s[1]; }
+    /// ditto
+    void popFront()() { opCall(); }
+    /// ditto
+    void seed()(ulong x0)
+    {
+        this.__ctor(x0);
+    }
 }
 
 ///
@@ -528,4 +551,20 @@ struct Xoroshiro128Plus
     //to 2 ^^ 64 invocations of opCall.
     gen.jump();
     auto n = gen();
+}
+
+@nogc nothrow pure @safe version(mir_random_test) unittest
+{
+    //Test Xoroshiro128Plus can be used as a Phobos-style random.
+    import std.random: isSeedable, isUniformRNG;
+    static assert(isUniformRNG!(Xoroshiro128Plus, ulong));
+    static assert(isSeedable!(Xoroshiro128Plus, ulong));
+    auto gen1 = Xoroshiro128Plus(1);
+    auto gen2 = Xoroshiro128Plus(2);
+    gen2.seed(1);
+    assert(gen1 == gen2);
+    immutable a = gen1.front;
+    gen1.popFront();
+    assert(a == gen2());
+    assert(gen1.front == gen2());
 }

--- a/source/mir/random/engine/xorshift.d
+++ b/source/mir/random/engine/xorshift.d
@@ -556,8 +556,8 @@ struct Xoroshiro128Plus
 @nogc nothrow pure @safe version(mir_random_test) unittest
 {
     //Test Xoroshiro128Plus can be used as a Phobos-style random.
-    import std.random: isSeedable, isUniformRNG;
-    static assert(isUniformRNG!(Xoroshiro128Plus, ulong));
+    import std.random: isSeedable, isPhobosUniformRNG = isUniformRNG;
+    static assert(isPhobosUniformRNG!(Xoroshiro128Plus, ulong));
     static assert(isSeedable!(Xoroshiro128Plus, ulong));
     auto gen1 = Xoroshiro128Plus(1);
     auto gen2 = Xoroshiro128Plus(2);

--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -446,7 +446,15 @@ T randExponential2(T, G)(ref G gen)
     auto v = gen.randExponential2!double();
 }
 
-import std.random: isPhobosUniformRNG = isUniformRNG;
+/++
+$(LINK2 https://dlang.org/phobos/std_random.html#.isUniformRNG,
+std.random.isUniformRNG!T)
++/
+template isPhobosUniformRNG(T)
+{
+    import std.random: isUniformRNG;
+    enum bool isPhobosUniformRNG = isUniformRNG!T;
+}
 
 /++
 Extends a Mir-style random number generator to also meet


### PR DESCRIPTION
This allows the new engines to be used with legacy libraries that expect
Phobos-style random number generators. It turns out that these most
recent additions are the only engines currently in the library that can
conveniently implement `front` without re-working.