### PR TITLE
Add thread-local randoms except when D_betterC

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -22,6 +22,10 @@
 		"unittest-cov": {
 			"buildOptions": ["unittests", "coverage", "debugMode", "debugInfo"],
 			"versions": ["mir_random_test"]
+		},
+		"unittest-release": {
+			"buildOptions": ["unittests", "releaseMode", "optimize", "inline", "noBoundsCheck"],
+			"versions": ["mir_random_test"]
 		}
 	},
  	"libs-windows": ["advapi32"]

--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -1,9 +1,49 @@
 /++
+$(SCRIPT inhibitQuickIndex = 1;)
 Uniform random engines.
+
+$(B Sections:)
+        $(LINK2 #Convenience, Convenience)
+&#8226; $(LINK2 #Entropy, Entropy)
+&#8226; $(LINK2 #Traits, Traits)
+&#8226; $(LINK2 #CInterface, C Interface)
+
+$(BOOKTABLE
+
+$(LEADINGROW <a id="Convenience"></a>Convenience)
+$(TR
+    $(RROW Random, Default random number _engine))
+    $(RROW rne, Per-thread uniquely-seeded instance of default `Random`. Requires $(LINK2 https://en.wikipedia.org/wiki/Thread-local_storage, TLS).)
+    $(TR $(TDNW $(LREF threadLocal)`!(Engine)`) $(TD Per-thread uniquely-seeded instance of of any specified `Engine`. Requires $(LINK2 https://en.wikipedia.org/wiki/Thread-local_storage, TLS).))
+
+$(LEADINGROW <a id="Entropy"></a>Entropy)
+$(TR
+    $(RROW unpredictableSeed, Seed of `size_t` using system entropy)
+    $(RROW unpredictableSeedOf, Generalization of `unpredictableSeed` for unsigned integers of different sizes)
+    $(RROW genRandomNonBlocking, Fills a buffer with system entropy, returning number of bytes copied or negative number on error)
+    $(RROW genRandomBlocking, Fills a buffer with system entropy, possibly waiting if the system believes it has insufficient entropy. Returns 0 on success.))
+
+$(LEADINGROW <a id="Traits"></a>Traits)
+$(TR
+    $(RROW isRandomEngine, Check if is random number _engine)
+    $(RROW EngineReturnType, Get return type of random number _engine's `opCall()`)
+    $(RROW isSaturatedRandomEngine, Check if random number _engine `G` such that `G.max == EngineReturnType!(G).max`)
+    $(RROW preferHighBits, Are the high bits of the _engine's output known to have better statistical properties than the low bits?))
+
+$(LEADINGROW <a id="CInterface"></a>C Interface)
+    $(RROW mir_random_engine_ctor, Perform any necessary setup. Automatically called by DRuntime.)
+    $(RROW mir_random_engine_dtor, Release any resources. Automatically called by DRuntime.)
+    $(RROW mir_random_genRandomNonBlocking, External name for $(LREF genRandomNonBlocking))
+    $(RROW mir_random_genRandomBlocking, External name for $(LREF genRandomBlocking))
+)
 
 Copyright: Ilya Yaroshenko 2016-.
 License:  $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Ilya Yaroshenko
+
+Macros:
+    T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
+    RROW = $(TR $(TDNW $(LREF $1)) $(TD $+))
 +/
 module mir.random.engine;
 
@@ -22,6 +62,11 @@ version (OpenBSD)
     version = GOOD_ARC4RANDOM_BUF;//ChaCha20
 version (NetBSD)
     version = GOOD_ARC4RANDOM_BUF;//ChaCha20
+
+version (D_betterC)
+    private enum bool THREAD_LOCAL_STORAGE_AVAILABLE = false;
+else
+    private enum bool THREAD_LOCAL_STORAGE_AVAILABLE = __traits(compiles, { static size_t x = 0; });
 
 import std.traits;
 
@@ -98,18 +143,36 @@ template preferHighBits(G)
         private enum bool preferHighBits = false;
 }
 
-/**
-A "good" seed for initializing random number engines. Initializing
-with $(D_PARAM unpredictableSeed) makes engines generate different
-random number sequences every run.
-
-Returns:
-A single unsigned integer seed value, different on each successive call
-*/
-pragma(inline, true)
-@property size_t unpredictableSeed() @trusted nothrow @nogc
+version (D_Ddoc)
 {
-    size_t seed;
+    /++
+    A "good" seed for initializing random number engines. Initializing
+    with $(D_PARAM unpredictableSeed) makes engines generate different
+    random number sequences every run.
+
+    Returns:
+    A single unsigned integer seed value, different on each successive call
+    +/
+    pragma(inline, true)
+    @property size_t unpredictableSeed() @trusted nothrow @nogc
+    {
+        return unpredictableSeedOf!size_t;
+    }
+}
+else
+{
+    //If D_Doc saw this it would produce incorrect documentation:
+    //instead of "size_t" it would say either "uint" or "ulong"
+    //depending on the machine generating the documentation (!!!)
+    public alias unpredictableSeed = unpredictableSeedOf!size_t;
+}
+
+/// ditto
+pragma(inline, true)
+@property T unpredictableSeedOf(T)() @trusted nothrow @nogc
+    if (isUnsigned!T && T.sizeof >= uint.sizeof)
+{
+    T seed = void;
     version (GOOD_ARC4RANDOM_BUF)
     {
         arc4random_buf(&seed, seed.sizeof);
@@ -161,9 +224,17 @@ pragma(inline, true)
         k ^= k >> 33;
         k *= 0xc4ceb9fe1a85ec53;
         k ^= k >> 33;
-        return cast(size_t)k;
+        seed = cast(T)k;
     }
     return seed;
+}
+
+/// ditto
+pragma(inline, true)
+@property T unpredictableSeedOf(T)() @safe nothrow @nogc
+    if (isUnsigned!T && T.sizeof < uint.sizeof)
+{
+    return cast(T) unpredictableSeedOf!uint;
 }
 
 ///
@@ -192,6 +263,148 @@ version(mir_random_test) unittest
     import std.traits;
     static assert(isSaturatedRandomEngine!Random);
     static assert(is(EngineReturnType!Random == size_t));
+}
+
+static if (THREAD_LOCAL_STORAGE_AVAILABLE)
+{
+    /++
+    Thread-local instance of the default $(LREF Random) allocated and seeded independently
+    for each thread. Requires $(LINK2 https://en.wikipedia.org/wiki/Thread-local_storage, TLS).
+    +/
+    alias rne = threadLocal!Random;
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+
+        int[10] array;
+        foreach (ref e; array)
+            e = rne.rand!int;
+        auto picked = array[rne.randIndex(array.length)];
+
+        import std.complex;
+        auto c = complex(rne.rand!real, rne.rand!real);
+    }
+
+    /++
+    Thread-local instance of the specified random number generator allocated and seeded uniquely
+    for each thread. Requires $(LINK2 https://en.wikipedia.org/wiki/Thread-local_storage, TLS).
+
+    `_rawThreadLocal!Engine` is the potentially-uninitialized area of thread-local storage
+    used by `threadLocal!Engine`. Normally you will not need to use `_rawThreadLocal`:
+    if you access the generator this way it may not have been seeded yet. But if you need
+    to take the address of the generator, `_rawThreadLocal` is public so the compiler can
+    tell it is `@safe`.
+    +/
+    @property ref Engine threadLocal(Engine)()
+        if (isSaturatedRandomEngine!Engine && is(Engine == struct))
+    {
+        pragma(inline, true);
+        import mir.ndslice.internal: _expect;
+        static bool initialized;
+        if (_expect(!initialized, false))
+        {
+            static if (is(typeof((ulong t) => Engine(t))))
+                alias seed_t = ulong;
+            else static if (is(typeof((uint t) => Engine(t))))
+                alias seed_t = uint;
+            else
+                alias seed_t = EngineReturnType!Engine;
+            static if (seed_t.sizeof <= uint.sizeof)
+                seed_t seed = cast(seed_t) unpredictableSeedOf!uint;
+            else
+                seed_t seed = unpredictableSeedOf!seed_t;
+            _rawThreadLocal!Engine.__ctor(seed);
+            initialized = true;
+        }
+        return _rawThreadLocal!Engine;
+    }
+    /// ditto
+    template _rawThreadLocal(Engine) if (isSaturatedRandomEngine!Engine && is(Engine == struct))
+    {
+        static if (__traits(compiles, { Engine defaultConstructed; }))
+            static Engine _rawThreadLocal;
+        else
+            static Engine _rawThreadLocal = Engine.init;
+    }
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+        import mir.random.engine.xorshift;
+
+        alias gen = threadLocal!Xorshift1024StarPhi;
+        double x = gen.rand!double;
+        size_t i = gen.randIndex(100u);
+    }
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+        import mir.random.engine.xorshift;
+
+        //If you need a pointer to the engine, getting it is @safe: just
+        //take the address of the static field. You will want
+        //to ensure that the engine is initialized, however.
+        threadLocal!Xorshift1024StarPhi;//<-- Will initialize and seed it if it wasn't already.        
+        Xorshift1024StarPhi *gen_ptr = &_rawThreadLocal!Xorshift1024StarPhi;
+    }
+    ///
+    @nogc nothrow @system version(mir_random_test) unittest
+    {
+        //Returns same instance every time per thread. 
+        import mir.random;
+        import mir.random.engine.xorshift;
+
+        Xorshift1024StarPhi* addr = &(threadLocal!Xorshift1024StarPhi());
+        Xorshift1024StarPhi* sameAddr = &(threadLocal!Xorshift1024StarPhi());
+        assert(sameAddr is &_rawThreadLocal!Xorshift1024StarPhi);
+    }
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+        import mir.random.engine.xorshift;
+
+        alias gen = threadLocal!Xorshift1024StarPhi;
+
+        //If you want to you can call the generator's opCall instead of using
+        //rand!T but it is somewhat clunky because of the ambiguity of
+        //@property syntax: () looks like optional function parentheses.
+        static assert(!__traits(compiles, {ulong x0 = gen();}));//<-- Won't work
+        static assert(is(typeof(gen()) == Xorshift1024StarPhi));//<-- because the type is this.
+        ulong x1 = gen.opCall();//<-- This works though.
+        ulong x2 = gen()();//<-- This also works.
+
+        //But instead of any of those you should really just use gen.rand!T.
+        ulong x3 = gen.rand!ulong;
+    }
+//    ///
+//    @nogc nothrow pure @safe version(mir_random_test) unittest
+//    {
+//        //If you want something like Phobos std.random.rndGen and
+//        //don't care about the specific algorithm you can do this:
+//        alias rndGen = threadLocal!Random;
+//    }
+}
+else
+{
+    static assert(!THREAD_LOCAL_STORAGE_AVAILABLE);
+
+    @property Random rne()()
+    {
+        static assert(0, "Thread-local storage not available!");
+    }
+
+    template threadLocal(T)
+    {
+        static assert(0, "Thread-local storage not available!");
+    }
+
+    template _rawThreadLocal(T)
+    {
+        static assert(0, "Thread-local storage not available!");
+    }
 }
 
 version(linux)

--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -280,165 +280,80 @@ static if (THREAD_LOCAL_STORAGE_AVAILABLE)
 
         auto c = complex(rne.rand!real, rne.rand!real);
 
-        //If you are going use rne several times in a row,
-        //it's more efficient to retain rne like this:
-        auto rng = rne;
         int[10] array;
         foreach (ref e; array)
-            e = rng.rand!int;
-        auto picked = array[rng.randIndex(array.length)];
+            e = rne.rand!int;
+        auto picked = array[rne.randIndex(array.length)];
     }
 
+    private static struct TL(Engine)
+        if (isSaturatedRandomEngine!Engine && is(Engine == struct))
+    {
+        static bool initialized;
+        static if (__traits(compiles, { Engine defaultConstructed; }))
+            static Engine engine;
+        else
+            static Engine engine = Engine.init;
+    }
     /++
     Thread-local instance of the specified random number generator allocated and seeded uniquely
     for each thread. Requires $(LINK2 https://en.wikipedia.org/wiki/Thread-local_storage, TLS).
+
+    `threadLocalPtr!Engine` is a pointer to the area of thread-local
+    storage used by `threadLocal!Engine`. This function is provided because
+    the compiler can infer it is `@safe`, unlike `&(threadLocal!Engine)`.
+    Like `threadLocal!Engine` this function will auto-initialize the engine.
+
+    `threadLocalInitialized!Engine` is a low-level way to explicitly change
+    the "intialized" flag used by `threadLocal!Engine` to determine whether
+    the Engine needs to be seeded. Setting this to `false` gives a way of
+    forcing the next call to `threadLocal!Engine` to reseed. In general this
+    is unnecessary but there are some specialized use cases where users have
+    requested this ability.
     +/
-    @property TL!Engine threadLocal(Engine)()
-        if (isSaturatedRandomEngine!Engine && is(Engine == struct) && !is(Engine: TL!(X), X))
+    @property ref Engine threadLocal(Engine)()
+        if (isSaturatedRandomEngine!Engine && is(Engine == struct))
     {
         version (DigitalMars)
-            pragma(inline);//DMD fails to inline this.
+            pragma(inline);//DMD may fail to inline this.
         else
             pragma(inline, true);
-        return TL!Engine(false);
+        return *threadLocalPtr!Engine;
     }
     /// ditto
-    @property TL!Engine2 threadLocal(Engine: TL!(Engine2), Engine2)()
-        if (isSaturatedRandomEngine!Engine && is(Engine == struct) && is(Engine: TL!(Engine2), Engine2))
+    @property Engine* threadLocalPtr(Engine)()
+        if (isSaturatedRandomEngine!Engine && is(Engine == struct))
     {
         version (DigitalMars)
-            pragma(inline);//DMD fails to inline this.
+            pragma(inline);//DMD may fail to inline this.
         else
             pragma(inline, true);
-        return TL!Engine2(false);
+        import mir.ndslice.internal: _expect;
+        if (_expect(!TL!Engine.initialized, false))
+        {
+            static if (is(typeof((ulong t) => Engine(t))))
+                alias seed_t = ulong;
+            else static if (is(typeof((uint t) => Engine(t))))
+                alias seed_t = uint;
+            else
+                alias seed_t = EngineReturnType!Engine;
+            static if (seed_t.sizeof <= uint.sizeof)
+                seed_t seed = cast(seed_t) unpredictableSeedOf!uint;
+            else
+                seed_t seed = unpredictableSeedOf!seed_t;
+            TL!Engine.engine.__ctor(seed);
+        }
+        return &(TL!Engine.engine);
     }
     /// ditto
-    struct TL(Engine)
-        if (isSaturatedRandomEngine!Engine && is(Engine == struct)
-            && !(__traits(compiles,
-                    {
-                        static assert(isSaturatedRandomEngine!(typeof(Engine._e))
-                            && isSaturatedRandomEngine!(typeof(Engine.engine))
-                            && is(typeof(Engine._i) == bool)
-                            && is(typeof(Engine.terminatedSafely) == bool));
-                    })))
+    @property ref bool threadLocalInitialized(Engine)()
+        if (isSaturatedRandomEngine!Engine && is(Engine == struct))
     {
-        static bool _i;//Tracks whether exited safely most recently.
-        static if (__traits(compiles, { Engine defaultConstructed; }))
-            static Engine _e;
+        version (DigitalMars)
+            pragma(inline);//DMD may fail to inline this.
         else
-            static Engine _e = Engine.init;
-
-        //Should these be disabled?
-        @disable this();
-        @disable this(this);
-
-        ///
-        public alias terminatedSafely = _i;
-        ///
-        public alias engine = _e;
-
-        private this()(bool _)
-        {
-            import mir.ndslice.internal: _expect;
-            //First initialize if needed:
-            if (_expect(!terminatedSafely, false))
-            {
-                static if (is(typeof((ulong t) => Engine(t))))
-                    alias seed_t = ulong;
-                else static if (is(typeof((uint t) => Engine(t))))
-                    alias seed_t = uint;
-                else
-                    alias seed_t = EngineReturnType!Engine;
-                static if (seed_t.sizeof <= uint.sizeof)
-                    seed_t seed = cast(seed_t) unpredictableSeedOf!uint;
-                else
-                    seed_t seed = unpredictableSeedOf!seed_t;
-                engine.__ctor(seed);
-            }
-            //Then set this in case we don't exit as expected:
-            terminatedSafely = false;
-        }
-
-        ~this() @nogc nothrow @safe
-        {
-            terminatedSafely = true;
-        }
-
-        /// Advance the random sequence.
-        EngineReturnType!Engine opCall()() { return engine.opCall(); }
-        ///
-        enum EngineReturnType!Engine max = Engine.max;
-        ///
-        enum bool isRandomEngine = true;
-        ///
-        enum bool preferHighBits = .preferHighBits!Engine;
-
-        //Document when the wrapper design is closer to final.
-        static if (__traits(compiles, { enum bool e = Engine.isUniformRandom; static assert(Engine.isUniformRandom);})
-            && is(Unqual!(EngineReturnType!Engine) == Unqual!(ReturnType!((ref Engine e) => e.front))))
-        {
-            /// If the original type had phobos compatibility, maintain it.
-            enum bool isUniformRandom = Engine.isUniformRandom;
-            enum EngineReturnType!Engine min = Engine.min;
-            enum bool empty = Engine.empty;
-        }
-
-        // Defines so can still be used when not LVALUE.
-        @property T rand(T)()
-            if (isIntegral!T || is(T == enum) || is(T == bool) || (isFloatingPoint!T))
-        {
-            return mir.random.rand!(T,Engine)(engine);
-        }
-        // ditto
-        @property T rand(T)(sizediff_t boundExp)
-            if (isFloatingPoint!T)
-        {
-            return mir.random.rand!(T,Engine)(engine, boundExp);
-        }
-        // ditto
-        @property T randIndex(T)(T m)
-            if (isUnsigned!T)
-        {
-            static import mir.random;
-            return mir.random.randIndex!(T,Engine)(engine, m);
-        }
-        // ditto
-        @property T randGeometric(T)(T m)
-            if (isUnsigned!T)
-        {
-            static import mir.random;
-            return mir.random.randGeometric!(T,Engine)(engine, m);
-        }
-        // ditto
-        @property T randExponential(T)(T m)
-            if (isUnsigned!T)
-        {
-            static import mir.random;
-            return mir.random.randExponential!(T,Engine)(engine, m);
-        }
-
-        /// Pointer to the thread-local copy of the engine.
-        @property Engine* ptr() @nogc nothrow @safe
-        {
-            return &engine;
-        }
-
-        ///
-        alias engine this;
-    }
-    /// ditto
-    template TL(Engine)
-        if (isSaturatedRandomEngine!Engine && is(Engine == struct)
-            && (__traits(compiles,
-                    {
-                        static assert(isSaturatedRandomEngine!(typeof(Engine._e))
-                            && isSaturatedRandomEngine!(typeof(Engine.engine))
-                            && is(typeof(Engine._i) == bool)
-                            && is(typeof(Engine.terminatedSafely) == bool));
-                    })))
-    {
-        alias TL = .TL!(typeof(Engine._e));
+            pragma(inline, true);
+        return TL!Engine.initialized;
     }
     ///
     @nogc nothrow @safe version(mir_random_test) unittest
@@ -446,48 +361,46 @@ static if (THREAD_LOCAL_STORAGE_AVAILABLE)
         import mir.random;
         import mir.random.engine.xorshift;
 
-        auto gen = threadLocal!Xorshift1024StarPhi;
+        alias gen = threadLocal!Xorshift1024StarPhi;
         double x = gen.rand!double;
         size_t i = gen.randIndex(100u);
-        ulong a = gen();
+        ulong a = gen.rand!ulong;
     }
     ///
     @nogc nothrow @safe version(mir_random_test) unittest
     {
         import mir.random;
-        //If you need a pointer to the engine, getting it is @safe:
-        Random* ptr = threadLocal!Random.ptr;
+        //If you need a pointer to the engine, getting it like this is @safe:
+        Random* ptr = threadLocalPtr!Random;
     }
-//    ///
-//    @nogc nothrow @system version(mir_random_test) unittest
-//    {
-//        //Returns same instance every time per thread.
-//        import mir.random;
-//        import mir.random.engine.xorshift;
-//
-//        Xorshift1024StarPhi* addr = &(threadLocal!Xorshift1024StarPhi());
-//        Xorshift1024StarPhi* sameAddr = &(threadLocal!Xorshift1024StarPhi());
-//        assert(sameAddr is &_rawThreadLocal!Xorshift1024StarPhi);
-//    }
-//    ///
-//    @nogc nothrow @safe version(mir_random_test) unittest
-//    {
-//        import mir.random;
-//        import mir.random.engine.xorshift;
-//
-//        alias gen = threadLocal!Xorshift1024StarPhi;
-//
-//        //If you want to you can call the generator's opCall instead of using
-//        //rand!T but it is somewhat clunky because of the ambiguity of
-//        //@property syntax: () looks like optional function parentheses.
-//        static assert(!__traits(compiles, {ulong x0 = gen();}));//<-- Won't work
-//        static assert(is(typeof(gen()) == Xorshift1024StarPhi));//<-- because the type is this.
-//        ulong x1 = gen.opCall();//<-- This works though.
-//        ulong x2 = gen()();//<-- This also works.
-//
-//        //But instead of any of those you should really just use gen.rand!T.
-//        ulong x3 = gen.rand!ulong;
-//    }
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+        import mir.random.engine.xorshift;
+        //If you need to mark the engine as uninitialized to force a reseed,
+        //you can do it like this:
+        threadLocalInitialized!Xorshift1024StarPhi = false;
+    }
+    ///
+    @nogc nothrow @safe version(mir_random_test) unittest
+    {
+        import mir.random;
+        import mir.random.engine.xorshift;
+
+        alias gen = threadLocal!Xorshift1024StarPhi;
+
+        //If you want to you can call the generator's opCall instead of using
+        //rand!T but it is somewhat clunky because of the ambiguity of
+        //@property syntax: () looks like optional function parentheses.
+        static assert(!__traits(compiles, {ulong x0 = gen();}));//<-- Won't work
+        static assert(is(typeof(gen()) == Xorshift1024StarPhi));//<-- because the type is this.
+        ulong x1 = gen.opCall();//<-- This works though.
+        ulong x2 = gen()();//<-- This also works.
+
+        //But instead of any of those you should really just use gen.rand!T.
+        ulong x3 = gen.rand!ulong;
+    }
 //    ///
 //    @nogc nothrow pure @safe version(mir_random_test) unittest
 //    {
@@ -496,28 +409,16 @@ static if (THREAD_LOCAL_STORAGE_AVAILABLE)
 //        alias rndGen = threadLocal!Random;
 //    }
 
-    @nogc nothrow @safe version (mir_random_test) unittest
+    @nogc nothrow @system version(mir_random_test) unittest
     {
-        //Test that we avoid pointless layers of recursion.
-        alias TLTL = TL!(TL!Random);
-        static assert(is(TLTL == TL!Random));
-
-        //Test that we preserve properties.
+        //Verify Returns same instance every time per thread.
         import mir.random;
         import mir.random.engine.xorshift;
-        alias TLX = TL!Xoroshiro128Plus;
-        static assert(isSaturatedRandomEngine!TLX);
-        static assert(isPhobosUniformRNG!TLX);
 
-        //Test some stuff works when not an LVALUE.
-        import mir.random.algorithm;
-        uint[10] array;
-        foreach (i, ref e; array)
-            e = rne.rand!uint;
-        static assert(
-            //FIXME: get the first to work with non-LVALUE rne using opDispatch, alias this, or something.
-            is(typeof(() => rne.shuffle(array[])))
-            || is(typeof(() => rne.engine.shuffle(array[]))));
+        Xorshift1024StarPhi* addr = &(threadLocal!Xorshift1024StarPhi());
+        Xorshift1024StarPhi* sameAddr = &(threadLocal!Xorshift1024StarPhi());
+        assert(addr is sameAddr);
+        assert(sameAddr is threadLocalPtr!Xorshift1024StarPhi);
     }
 
 }
@@ -525,7 +426,7 @@ else
 {
     static assert(!THREAD_LOCAL_STORAGE_AVAILABLE);
 
-    @property Random rne()()
+    @property ref Random rne()()
     {
         static assert(0, "Thread-local storage not available!");
     }
@@ -535,7 +436,12 @@ else
         static assert(0, "Thread-local storage not available!");
     }
 
-    template _rawThreadLocal(T)
+    template threadLocalPtr(T)
+    {
+        static assert(0, "Thread-local storage not available!");
+    }
+
+    template threadLocalInitialized(T)
     {
         static assert(0, "Thread-local storage not available!");
     }

--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -296,14 +296,20 @@ static if (THREAD_LOCAL_STORAGE_AVAILABLE)
     @property TL!Engine threadLocal(Engine)()
         if (isSaturatedRandomEngine!Engine && is(Engine == struct) && !is(Engine: TL!(X), X))
     {
-        pragma(inline, true);
+        version (DigitalMars)
+            pragma(inline);//DMD fails to inline this.
+        else
+            pragma(inline, true);
         return TL!Engine(false);
     }
     /// ditto
     @property TL!Engine2 threadLocal(Engine: TL!(Engine2), Engine2)()
         if (isSaturatedRandomEngine!Engine && is(Engine == struct) && is(Engine: TL!(Engine2), Engine2))
     {
-        pragma(inline, true);
+        version (DigitalMars)
+            pragma(inline);//DMD fails to inline this.
+        else
+            pragma(inline, true);
         return TL!Engine2(false);
     }
     /// ditto


### PR DESCRIPTION
For issue https://github.com/libmir/mir-random/issues/41

**(EDIT: below info is outdated. New names are `rne`, `threadLocal!Engine`, `threadLocalPtr!Engine`, and `threadLocalInitialized!Engine`).**
Includes
```
rndGen
threadLocal!Engine
_rawThreadLocal!Engine
```
but I'm not sure it's really desirable to have all of those. `_rawThreadLocal` exposes the static field just so the compiler can tell that it's safe to take the address, if for some reason you need the address of the engine. If there's a way to make the compiler not complain `"cannot take address of ref return of threadLocal() in @safe function"` that would be better.

Also made the documentation look a bit nicer while I was making changes.