### PR TITLE
`@safe unittest` for ndvariable and flex

### DIFF
--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -46,10 +46,10 @@ version(unittest)
     }
     version(Flex_fpEqual)
     {
-        bool fpEqual(float a, float b) { 
+        bool fpEqual(float a, float b) @nogc nothrow pure @safe {
             import std.math : approxEqual;
             return a.approxEqual(b, 1e-5, 1e-5); }
-        bool fpEqual(double a, double b) {
+        bool fpEqual(double a, double b) @nogc nothrow pure @safe {
             import std.math : approxEqual;
             return a.approxEqual(b, 1e-14, 1e-14); }
 
@@ -58,7 +58,7 @@ version(unittest)
         else
             enum real maxError = 1e-18;
 
-        bool fpEqual(real a, real b) {
+        bool fpEqual(real a, real b) @nogc nothrow pure @safe {
             import std.math : approxEqual;
             return a.approxEqual(b, 1e-18, 1e-18); }
     }
@@ -157,7 +157,7 @@ void determineSqueezeAndHat(S)(ref Interval!S iv)
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.meta : AliasSeq;
     import mir.random.flex.internal.types: determineType;
@@ -191,7 +191,7 @@ version(mir_random_test) unittest
 }
 
 // test undefined type
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math : fabs, log;
     import mir.random.flex.internal.transformations : transformInterval;
@@ -222,7 +222,7 @@ version(mir_random_test) unittest
 }
 
 // T4a with infinity
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     alias S = double;
     static import std.math;
@@ -438,13 +438,13 @@ body
 
 // example from Botts et al. (2013) (distribution 1)
 // split up into all three floating-point types
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     alias S = float;
 
@@ -500,7 +500,8 @@ version(mir_random_test) unittest
     // calculate the area of all intervals
     foreach (i, c; cs)
     {
-        foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+        size_t j = 0;
+        foreach (p1, p2; points.zip(points.save.dropOne))
         {
             auto iv = it(p1, p2, c);
             version(Flex_logging)
@@ -522,17 +523,19 @@ version(mir_random_test) unittest
 
             squeezeArea!S(iv);
             assert(iv.squeezeArea.fpEqual(sqs[i][j]));
+
+            ++j;
         }
     }
 }
 
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     alias S = double;
 
@@ -588,7 +591,8 @@ version(mir_random_test) unittest
     // calculate the area of all intervals
     foreach (i, c; cs)
     {
-        foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+        size_t j = 0;
+        foreach (p1, p2; points.zip(points.save.dropOne))
         {
             auto iv = it(p1, p2, c);
             version(Flex_logging)
@@ -610,17 +614,19 @@ version(mir_random_test) unittest
 
             squeezeArea!S(iv);
             assert(iv.squeezeArea.fpEqual(sqs[i][j]));
+
+            ++j;
         }
     }
 }
 
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     alias S = real;
 
@@ -676,7 +682,8 @@ version(mir_random_test) unittest
     // calculate the area of all intervals
     foreach (i, c; cs)
     {
-        foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+        size_t j = 0;
+        foreach (p1, p2; points.zip(points.save.dropOne))
         {
             auto iv = it(p1, p2, c);
             version(Flex_logging)
@@ -711,18 +718,20 @@ version(mir_random_test) unittest
 
             assert(iv.hatArea.approxEqual(hats[i][j]));
             assert(iv.squeezeArea.approxEqual(sqs[i][j]));
+
+            ++j;
         }
     }
 }
 
 // standard normal distribution
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     static immutable points = [-3.0, -1.5, 0.0, 1.5, 3];
     static immutable cs = [50, 30, -20, -15, -10, -5, -3, -1, -0.5 -0.1, 0,
@@ -794,7 +803,8 @@ version(mir_random_test) unittest
         // calculate the area of all intervals
         foreach (i, c; cs)
         {
-            foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+            size_t j = 0;
+            foreach (p1, p2; points.zip(points.save.dropOne))
             {
                 auto iv = it(p1, p2, c);
                 determineSqueezeAndHat(iv);
@@ -804,19 +814,21 @@ version(mir_random_test) unittest
 
                 squeezeArea!S(iv);
                 assert(iv.squeezeArea.approxEqual(sqs[i][j]));
+
+                ++j;
             }
         }
     }
 }
 
 // distribution 3
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual, isInfinity;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     alias T = double;
 
@@ -869,7 +881,8 @@ version(mir_random_test) unittest
         // calculate the area of all intervals
         foreach (i, c; cs)
         {
-            foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+            size_t j = 0;
+            foreach (p1, p2; points.zip(points.save.dropOne))
             {
                 auto iv = it(p1, p2, c);
 
@@ -883,19 +896,21 @@ version(mir_random_test) unittest
 
                 squeezeArea!S(iv);
                 assert(iv.squeezeArea.approxEqual(sqs[i][j]));
+
+                ++j;
             }
         }
     }
 }
 
 // distribution 4
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: abs, approxEqual, isInfinity;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     static immutable points = [-1, -0.5, 0, 0.5, 1];
     // -2 yields "undefined" type
@@ -941,7 +956,8 @@ version(mir_random_test) unittest
         // calculate the area of all intervals
         foreach (i, c; cs)
         {
-            foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+            size_t j = 0;
+            foreach (p1, p2; points.zip(points.save.dropOne))
             {
                 auto iv = it(p1, p2, c);
                 determineSqueezeAndHat(iv);
@@ -954,19 +970,21 @@ version(mir_random_test) unittest
 
                 squeezeArea!S(iv);
                 assert(iv.squeezeArea.approxEqual(sqs[i][j]));
+
+                ++j;
             }
         }
     }
 }
 
 // distribution 4 with less points
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: abs, approxEqual, isInfinity;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     static immutable points = [-1, 0, 1];
     // -2 yields "undefined" type
@@ -1016,7 +1034,8 @@ version(mir_random_test) unittest
         // calculate the area of all intervals
         foreach (i, c; cs)
         {
-            foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+            size_t j = 0;
+            foreach (p1, p2; points.zip(points.save.dropOne))
             {
                 auto iv = it(p1, p2, c);
                 determineSqueezeAndHat(iv);
@@ -1030,19 +1049,21 @@ version(mir_random_test) unittest
 
                 squeezeArea!S(iv);
                 assert(iv.squeezeArea.approxEqual(sqs[i][0]));
+
+                ++j;
             }
         }
     }
 }
 
 // distribution 3 with other boundaries
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import mir.random.flex.internal.transformations : transformInterval;
     import mir.random.flex.internal.types : determineType;
     import std.math: approxEqual, isInfinity;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
 
     alias T = double;
 
@@ -1084,7 +1105,8 @@ version(mir_random_test) unittest
         // calculate the area of all intervals
         foreach (i, c; cs)
         {
-            foreach (j, p1, p2; points.lockstep(points.save.dropOne))
+            size_t j = 0;
+            foreach (p1, p2; points.zip(points.save.dropOne))
             {
                 auto iv = it(p1, p2, c);
                 determineSqueezeAndHat(iv);
@@ -1094,6 +1116,8 @@ version(mir_random_test) unittest
 
                 squeezeArea!S(iv);
                 assert(iv.squeezeArea.approxEqual(sqs[i][j]));
+
+                ++j;
             }
         }
     }
@@ -1128,3 +1152,4 @@ body
     assert(iv.hatArea.isFinite, "hat area should be lower than infinity");
     assert(iv.squeezeArea.isFinite, "squeezeArea area should be lower than infinity");
 }
+//calcInterval tested in mir.random.flex.d.

--- a/source/mir/random/flex/internal/transformations.d
+++ b/source/mir/random/flex/internal/transformations.d
@@ -78,7 +78,7 @@ body
 }
 
 // example from Botts et al. (2013)
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math: approxEqual;
     import std.meta : AliasSeq;
@@ -101,11 +101,12 @@ version(mir_random_test) unittest
 }
 
 // test for c=1
-version(mir_random_test) unittest
+pure @safe version(mir_random_test) unittest
 {
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
+    //Use zip instead of lockstep because lockstep fails to infer @safe-ty here.
     foreach (S; AliasSeq!(float, double, real))
     {
         auto f0 = (S x) => -x^^4 + 5 * x^^2 - 4;
@@ -121,23 +122,26 @@ version(mir_random_test) unittest
         S[] resT2x = [2.54306485721755e-14, -131.4653189726813878,
                       0.1831563888873418, -1.31465318972681e+02];
 
-        foreach (i, l, r; lockstep(points, points.save.dropOne))
+        size_t i = 0;
+        foreach (l, r; zip(points, points.save.dropOne))
         {
             auto iv = Interval!S(l, r, c, f0(l), f1(l), f2(l), f0(r), f1(r), f2(r));
             iv.transformInterval;
             assert(iv.ltx.approxEqual(resT0x[i]));
             assert(iv.lt1x.approxEqual(resT1x[i]));
             assert(iv.lt2x.approxEqual(resT2x[i]));
+            ++i;
         }
     }
 }
 
 // test for c=-1
-version(mir_random_test) unittest
+pure @safe version(mir_random_test) unittest
 {
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
+    //Use zip instead of lockstep because lockstep fails to infer @safe-ty here.
     foreach (S; AliasSeq!(float, double, real))
     {
         auto f0 = (S x) => -x^^4 + 5 * x^^2 - 4;
@@ -155,23 +159,26 @@ version(mir_random_test) unittest
                       545.9815003314423620, -2.15979014251662e+00,
                       -1.45515171958646e+21];
 
-        foreach (i, l, r; lockstep(points, points.save.dropOne))
+        size_t i = 0;
+        foreach (l, r; zip(points, points.save.dropOne))
         {
             auto iv = Interval!S(l, r, c, f0(l), f1(l), f2(l), f0(r), f1(r), f2(r));
             iv.transformInterval;
             assert(iv.ltx.approxEqual(resT0x[i]));
             assert(iv.lt1x.approxEqual(resT1x[i]));
             assert(iv.lt2x.approxEqual(resT2x[i]));
+            ++i;
         }
     }
 }
 
 // test for c=0
-version(mir_random_test) unittest
+pure @safe version(mir_random_test) unittest
 {
     import std.math: approxEqual;
     import std.meta : AliasSeq;
-    import std.range: dropOne, lockstep, save;
+    import std.range: dropOne, save, zip;
+    //Use zip instead of lockstep because lockstep fails to infer @safe-ty here.
     foreach (S; AliasSeq!(float, double, real))
     {
         auto f0 = (S x) => -x^^4 + 5 * x^^2 - 4;
@@ -184,19 +191,21 @@ version(mir_random_test) unittest
         S[] resT1x = [78, -1.5,  0,  1.5, -78];
         S[] resT2x = [-98, -17, 10,-17, -98];
 
-        foreach (i, l, r; lockstep(points, points.save.dropOne))
+        size_t i = 0;
+        foreach (l, r; zip(points, points.save.dropOne))
         {
             auto iv = Interval!S(l, r, c, f0(l), f1(l), f2(l), f0(r), f1(r), f2(r));
             iv.transformInterval;
             assert(iv.ltx.approxEqual(resT0x[i]));
             assert(iv.lt1x.approxEqual(resT1x[i]));
             assert(iv.lt2x.approxEqual(resT2x[i]));
+            ++i;
         }
     }
 }
 
 // test with exact values
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     alias S = float;
     S c = -0.9;
@@ -254,7 +263,7 @@ body
     return v * p;
 }
 
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math: E, approxEqual;
     import std.meta : AliasSeq;
@@ -265,7 +274,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math;
     import std.meta : AliasSeq;
@@ -297,7 +306,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math;
     import std.meta : AliasSeq;
@@ -348,7 +357,7 @@ S inverseAntiderivative(S)(in S x, in S c)
     return pow(d / fabs(c) * x, c / d).copysign(c);
 }
 
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math: approxEqual, E, isNaN;
     import std.meta : AliasSeq;
@@ -371,7 +380,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.math;
     import std.meta : AliasSeq;
@@ -408,7 +417,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.math;
     import std.meta : AliasSeq;

--- a/source/mir/random/flex/internal/types.d
+++ b/source/mir/random/flex/internal/types.d
@@ -220,7 +220,7 @@ body
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.meta : AliasSeq;
     foreach (S; AliasSeq!(float, double, real)) with(FunType)
@@ -240,7 +240,7 @@ version(mir_random_test) unittest
 }
 
 // test x^3
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.meta : AliasSeq;
     foreach (S; AliasSeq!(float, double, real)) with(FunType)
@@ -264,7 +264,7 @@ version(mir_random_test) unittest
 }
 
 // test sin(x)
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math: PI;
     // due to numerical errors a small padding must be added
@@ -318,7 +318,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.meta : AliasSeq;
     foreach (S; AliasSeq!(float, double, real)) with(FunType)
@@ -370,10 +370,8 @@ struct LinearFun(S)
         this.a = a;
     }
 
-    /// textual representation of the function
-    void toString(scope void delegate(const(char)[]) sink,
-                  FormatSpec!char fmt) const
-    {
+    private enum string _toString =
+    q{
         import std.range : put;
         import std.format: formatValue, singleSpec;
         switch(fmt.spec)
@@ -418,6 +416,19 @@ struct LinearFun(S)
                 sink.put(")");
                 break;
         }
+    };
+
+    /// textual representation of the function
+    void toString()(scope void delegate(const(char)[]) @system sink,
+                  FormatSpec!char fmt) const
+    {
+        mixin(_toString);
+    }
+    /// ditto
+    void toString()(scope void delegate(const(char)[]) @safe sink,
+                  FormatSpec!char fmt) const
+    {
+        mixin(_toString);
     }
 
     /// call the linear function with x
@@ -464,7 +475,7 @@ LinearFun!S linearFun(S)(S slope, S y, S a)
 }
 
 /// tangent of a point
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.format : format;
     auto f = (double x) => x * x + 1;
@@ -488,7 +499,7 @@ version(mir_random_test) unittest
 }
 
 /// secant of two points
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.format : format;
     auto f = (double x) => x * x + 1;
@@ -502,7 +513,7 @@ version(mir_random_test) unittest
 }
 
 /// construct an arbitrary linear function
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.format : format;
 
@@ -513,7 +524,7 @@ version(mir_random_test) unittest
     assert(t(-2) == -3);
 }
 
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     import std.meta : AliasSeq;
     foreach (S; AliasSeq!(float, double, real))
@@ -530,7 +541,7 @@ version(mir_random_test) unittest
     }
 }
 
-version(mir_random_test) unittest
+nothrow pure @safe version(mir_random_test) unittest
 {
     import std.math : cos;
     import std.math : PI, approxEqual;
@@ -550,7 +561,7 @@ version(mir_random_test) unittest
 }
 
 // test default toString
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.format : format;
     auto t = linearFun!double(2, 0, 1);
@@ -558,7 +569,7 @@ version(mir_random_test) unittest
 }
 
 // test NaN behavior
-version(mir_random_test) unittest
+@safe version(mir_random_test) unittest
 {
     import std.format : format;
     auto t = linearFun!double(double.nan, 0, 1);
@@ -587,7 +598,7 @@ bool approxEqual(S)(LinearFun!S x, LinearFun!S y, S maxRelDiff = 1e-2, S maxAbsD
 }
 
 ///
-version(mir_random_test) unittest
+@nogc nothrow pure @safe version(mir_random_test) unittest
 {
     auto x = linearFun!double(2, 0, 1);
     auto x2 = linearFun!double(2, 0, 1);


### PR DESCRIPTION
Part of ongoing effort https://github.com/libmir/mir-random/issues/40

`mir.random.flex.internal.package` doesn't yet have coverage because `mir.math.sum.Summator` is unsafe.