### PR TITLE
unpredictableSeed: change to non-blocking

### DIFF
--- a/source/mir/random/engine/package.d
+++ b/source/mir/random/engine/package.d
@@ -170,7 +170,7 @@ else
 /// ditto
 pragma(inline, true)
 @property T unpredictableSeedOf(T)() @trusted nothrow @nogc
-    if (isUnsigned!T && T.sizeof >= uint.sizeof)
+    if (isUnsigned!T)
 {
     T seed = void;
     version (GOOD_ARC4RANDOM_BUF)
@@ -178,7 +178,7 @@ pragma(inline, true)
         arc4random_buf(&seed, seed.sizeof);
     }
     // fallback to old time/thread-based implementation in case of errors
-    else if (genRandomBlocking(&seed, seed.sizeof) < 0)
+    else if (genRandomNonBlocking(&seed, seed.sizeof) != T.sizeof)
     {
         version(Windows)
         {
@@ -227,14 +227,6 @@ pragma(inline, true)
         seed = cast(T)k;
     }
     return seed;
-}
-
-/// ditto
-pragma(inline, true)
-@property T unpredictableSeedOf(T)() @safe nothrow @nogc
-    if (isUnsigned!T && T.sizeof < uint.sizeof)
-{
-    return cast(T) unpredictableSeedOf!uint;
 }
 
 ///


### PR DESCRIPTION
Pinging @wilzbach - do we have a reason to use `genRandomBlocking` instead of `genRandomNonBlocking`?