### PR TITLE
Remove 'alias this' from PhobosRandom wrapper

### DIFF
--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -640,9 +640,6 @@ struct PhobosRandom(Engine) if (isRandomEngine!Engine && !isPhobosUniformRNG!Eng
     {
         return _engine;
     }
-
-    ///
-    alias engine this;
 }
 /// ditto
 template PhobosRandom(Engine) if (isRandomEngine!Engine && isPhobosUniformRNG!Engine)
@@ -676,7 +673,4 @@ template PhobosRandom(Engine) if (isRandomEngine!Engine && isPhobosUniformRNG!En
     gen.__ctor(1);
     rng.seed(1);
     assert(gen() == rng());
-
-    //Can still access unique methods due to "alias this":
-    rng.jump();
 }


### PR DESCRIPTION
`jump` example didn't work properly (sequence is different from non-wrapped engine) because underlying engine doesn't know to update opCall. Other possible methods would have similar problems so it is better to remove `alias this`.

`.engine` property is still available for directly calling methods of Engine.
