### PR TITLE
Temporarily disable osx builds in Travis CI because of very long wait times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 os:
  - linux
- - osx
+# Temporarily disable osx builds in Travis CI because of very long wait times
+# - osx
 language: d
 d:
  - ldc


### PR DESCRIPTION
[The last build](https://travis-ci.org/libmir/mir-random/builds/329747617) waited for 11 hours without starting any of the OS X builds. DMD has also disabled Travis testing for this reason (https://github.com/dlang/dmd/pull/7721).