### PR TITLE
Make XorshiftEngine template work with any UIntType

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation: http://docs.random.dlang.io/latest/index.html
 /+ dub.json:
 {
     "name": "test_random",
-    "dependencies": {"mir-random": "~>0.3.3"}
+    "dependencies": {"mir-random": "~>0.4.0"}
 }
 +/
 
@@ -47,7 +47,7 @@ void main()
 /+ dub.json:
 {
     "name": "test_random",
-    "dependencies": {"mir-random": "~>0.3.3"}
+    "dependencies": {"mir-random": "~>0.4.0"}
 }
 +/
 
@@ -112,5 +112,6 @@ void main(){
  - 64-bit Mt19937 is default for 64-bit targets
  - Permuted Congruential Generators (new)
  - SplitMix generators (new)
+ - Fixed XorshiftEngine's support for non-`uint` word sizes & allow various shift directions
  - XorshiftStar Generators (new)
  - Xoroshiro128Plus generator (new)

--- a/index.d
+++ b/index.d
@@ -72,7 +72,7 @@ $(BOOKTABLE ,
     )
     $(TR
         $(TDNW $(MREF mir,random,engine,xorshift))
-        $(TD $(HTTP xoroshiro.di.unimi.it, xoroshiro128+), $(HTTP en.wikipedia.org/wiki/Xorshift#xorshift.2A, xorshift1024*φ), xorshift64*/32, and legacy $(HTTP en.wikipedia.org/wiki/Xorshift, xorshift) generators.)
+        $(TD $(HTTP xoroshiro.di.unimi.it, xoroshiro128+), $(HTTP en.wikipedia.org/wiki/Xorshift#xorshift.2A, xorshift1024*φ), xorshift64*/32, and $(HTTP en.wikipedia.org/wiki/Xorshift, xorshift) generators.)
     )
 )
 

--- a/source/mir/random/engine/xorshift.d
+++ b/source/mir/random/engine/xorshift.d
@@ -58,7 +58,8 @@ Params:
 Note:
 For historical compatibility when `bits == 192` and `UIntType` is `uint`
 a legacy hybrid PRNG is used consisting of a 160-bit xorshift combined
-with a 32-bit counter. This combined generator has period `2^^192 - 2^^32`.
+with a 32-bit counter. This combined generator has period equal to the
+least common multiple of `2 ^^ 160 - 1` and `2 ^^ 32`.
 +/
 struct XorshiftEngine(UIntType, uint bits, int sa, int sb, int sc)
 if (isUnsigned!UIntType)
@@ -247,8 +248,8 @@ template XorshiftEngine(uint bits, uint a, uint b, uint c)
 }
 
 /++
-Define `XorshiftEngine` generators with well-chosen parameters. See each bits examples of "Xorshift RNGs".
-`Xorshift` an alias of one of the generators in this module.
+Define `XorshiftEngine` generators with well-chosen parameters for 32-bit architectures.
+`Xorshift` is an alias of one of the generators in this module.
 +/
 alias Xorshift32  = XorshiftEngine!(32,  13, 17, 15) ;
 alias Xorshift64  = XorshiftEngine!(64,  10, 13, 10); /// ditto


### PR DESCRIPTION
Make XorshiftEngine template work with any UIntType while maintaining full backward compatibility. Unittests in `mir.random.algorithm` verified that the results did not change.