### PR TITLE
Fix disallowed overlapping slice assignment in 2-word and 3-word XorshiftStar

### DIFF
--- a/source/mir/random/engine/xorshift.d
+++ b/source/mir/random/engine/xorshift.d
@@ -317,7 +317,9 @@ if (isIntegral!StateUInt && isIntegral!OutputUInt
         else static if (!usePointer)
         {
             auto s1 = s[0];
-            s[0 .. (N-1)] = s[1 .. N];
+            import mir.internal.utility: Iota;
+            foreach (i; Iota!(N - 1))
+                s[i] = s[i + 1];
             const s0 = s[N-1];
             s1 ^= s1 << a;
             s[N-1] = s1 ^ s0 ^ (s1 >>> b) ^ (s0 >>> c);


### PR DESCRIPTION
Fix a mistake I made in the xorshift* template. Fortunately does not affect either of the predefined xorshift* generators, since the code branch is only taken when the internal array is length 2 or 3. (At length 1 there is no need to move items within the array, and at lengths 4 and greater an index is used instead.)