### PR TITLE
Update run.dlang.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ void main()
 }
 ```
 
-[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/2pgbti)
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/mTVJL6)
 
 
 ### Example (10 seconds)
@@ -69,7 +69,7 @@ void main(){
 }
 ```
 
-[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/Uasbw1)
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/F1Iucp)
 
 
 ## Comparison with Phobos


### PR DESCRIPTION
This time I used "~>0.4" for the links, s.t. they don't need frequent updates.
("~>0.4" matches alll 0.X, whereas `~>0.3.5` only matches 0.3.x)