### PR TITLE
Alter unittest flex `fpEqual` to allow dlang/phobos#6272

### DIFF
--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -21,46 +21,16 @@ FP operations depend on
 */
 version(unittest)
 {
-    // the difference is marginal, but measurable
-    version(Windows)
+    import std.traits : isFloatingPoint;
+    /+
+    Approximate equality. Arguments must match except in the last two bits
+    of the mantissa.
+    +/
+    bool fpEqual(S)(in S a, in S b) @nogc nothrow pure @safe
+    if (isFloatingPoint!S)
     {
-        version = Flex_fpEqual;
-    }
-    else
-    {
-        version(DigitalMars)
-        {
-            version(X86_64)
-            {
-                alias fpEqual = (a, b) => a == b;
-            }
-            else
-            {
-                version = Flex_fpEqual;
-            }
-        }
-        else
-        {
-            version = Flex_fpEqual;
-        }
-    }
-    version(Flex_fpEqual)
-    {
-        bool fpEqual(float a, float b) @nogc nothrow pure @safe {
-            import std.math : approxEqual;
-            return a.approxEqual(b, 1e-5, 1e-5); }
-        bool fpEqual(double a, double b) @nogc nothrow pure @safe {
-            import std.math : approxEqual;
-            return a.approxEqual(b, 1e-14, 1e-14); }
-
-        version(Windows)
-            enum real maxError = 1e-14;
-        else
-            enum real maxError = 1e-18;
-
-        bool fpEqual(real a, real b) @nogc nothrow pure @safe {
-            import std.math : approxEqual;
-            return a.approxEqual(b, 1e-18, 1e-18); }
+        import std.math : feqrel;
+        return feqrel(a, b) >= S.mant_dig - 2;
     }
 }
 


### PR DESCRIPTION
For dlang/phobos#6272 which slightly changes result of `std.math.exp`. _Not 100% sure if changing this test is the right thing to do!_

Now on all platforms `fpEqual` requires all but the last two bits of the mantissas to match. Previously (only) with DMD on X86_64 `fpEqual` was exact equality. (The current test does not require exact equality with LDC, but I checked and the test still passes on X86_64 with LDC if `fpEqual` is changed to require exact equality.)