### PR TITLE
In arcmean use at least double precision tan/atan (due to dlang/phobos#6272)

### DIFF
--- a/source/mir/random/flex/internal/calc.d
+++ b/source/mir/random/flex/internal/calc.d
@@ -27,14 +27,19 @@ References:
 auto arcmean(S)(in ref Interval!S iv)
 {
     import std.math: atan, tan;
+    // Use at least double precision trigonometric functions.
+    static if (S.mant_dig < double.mant_dig)
+        alias T = double;
+    else
+        alias T = S;
 
     with(iv)
     {
         if (rx < -S(1e3) || lx > S(1e3))
             return 2 / (1 / lx + 1 / rx);
 
-        immutable d = atan(lx);
-        immutable b = atan(rx);
+        immutable d = atan(cast(T) lx);
+        immutable b = atan(cast(T) rx);
 
         assert(d <= b);
         if (b - d < S(1e-6))


### PR DESCRIPTION
Currently `std.math.tan/atan` are calculated using extended precision but dlang/phobos#6272 adds specializations for `float` and `double`. To pass current unittests we need to explicitly use double or extended precision `tan`/`atan` even when `S` is a single-precision.