### PR TITLE
Add Xoshiro256StarStar (xoshiro256**) generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ void main(){
  - Fixed XorshiftEngine's support for non-`uint` word sizes & allow various shift directions
  - XorshiftStar Generators (new)
  - Xoroshiro128Plus generator (new)
+ - Xoshiro256StarStar generator (new)

--- a/index.d
+++ b/index.d
@@ -72,7 +72,7 @@ $(BOOKTABLE ,
     )
     $(TR
         $(TDNW $(MREF mir,random,engine,xorshift))
-        $(TD $(HTTP xoroshiro.di.unimi.it, xoroshiro128+), $(HTTP en.wikipedia.org/wiki/Xorshift#xorshift.2A, xorshift1024*φ), xorshift64*/32, and $(HTTP en.wikipedia.org/wiki/Xorshift, xorshift) generators.)
+        $(TD $(HTTP http://xoshiro.di.unimi.it, xoshiro256**), $(HTTP en.wikipedia.org/wiki/Xoroshiro128%2B, xoroshiro128+), $(HTTP en.wikipedia.org/wiki/Xorshift#xorshift.2A, xorshift1024*φ), xorshift64*/32, and $(HTTP en.wikipedia.org/wiki/Xorshift, xorshift) generators.)
     )
 )
 


### PR DESCRIPTION
`xoshiro256**` is described in the paper [_Scrambled Linear Pseudorandom Number Generators_ (Blackman & Vigna, 2018)](https://arxiv.org/pdf/1805.01407.pdf).

From an end-user's standpoint I think the pertinent details are that `xoshiro256**` is 15% slower than [`xoroshiro128+`](https://en.wikipedia.org/wiki/Xoroshiro128%2B) but its low bits don't fail binary rank tests, and `xoshiro256**` is fully (4-dimensionally) equidistributed while `xoroshiro128+` is only 1-dimensionally equidistributed, and (to state the obvious)  `xoshiro256**` has 256 bits of state and a 2^^256-1 period instead of 128 bits of state and a 2^^128-1 period.