### PR TITLE
Don't run meson build with Buildkite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
  - dub test --arch "$ARCH"
  - dub build --root=examples/flex_plot
  # - dub build --root=examples/flex_plot/flex_common_pack
- - meson build && cd build && ninja -j4 && ninja test -v && cd ..
+ - if [ ! -z ${BUILDKITE} ]; then meson build && cd build && ninja -j4 && ninja test -v && cd ..; fi
 
 build_script:
  - echo dummy build script - dont remove me


### PR DESCRIPTION
```
Buildkite is used by DMD to ensure downstream projects are not broken.
Using meson here forces Buildkite agents to depend on meson.
While it would be possible to do so, that requires some work and coordination,
and might get delayed. In the meantime, just disable meson when buildkit is defined.
```

If possible, I'd like to get this in v1.0.1, as we check out the latest release.