### PR TITLE
Fix documentation of rand!IntType: min result is IntType.min not 0

### DIFF
--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -67,7 +67,7 @@ else
 Params:
     gen = saturated random number generator
 Returns:
-    Uniformly distributed integer for interval `[0 .. T.max]`.
+    Uniformly distributed integer for interval `[T.min .. T.max]`.
 +/
 T rand(T, G)(scope ref G gen)
     if (isSaturatedRandomEngine!G && isIntegral!T && !is(T == enum))


### PR DESCRIPTION
I assume the documentation is wrong, but if it is not then the behavior must be fixed instead.