### PR TITLE
Rename unpredictableSeedOf!UIntType to unpredictableSeed!UIntType

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ void main()
  - `opCall` API instead of range interface is used (similar to C++)
  - No default and copy constructors are allowed for generators.
  - `unpredictableSeed` has not state, returns `size_t`
+ - `unpredictableSeed!UIntType` overload for seeds of any unsigned type (merged to Phobos)
  - Any unsigned generators are allowed.
  - `min` property was removed. Any integer generator can normalize its minimum down to zero.
  - Mt19937: +100% performance for initialization. (merged to Phobos)


### PR DESCRIPTION
Fewer letters and matches new overload in Phobos std.random (https://github.com/dlang/phobos/pull/6580).