### PR TITLE
Implementation of Multinomial random variable

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ description "Dlang Random Number Generators"
 copyright "Copyright © 2016-2018, Ilya Yaroshenko (default), see also copyright per file"
 license "BSL-1.0 (default), Apache License, Version 2.0 for PCG"
 
-dependency "mir-core" version=">=0.2.0 <0.4.0"
+dependency "mir-core" version=">=0.2.0 <1.1.0"
 dependency "mir-linux-kernel" version="~>1.0.0"  platform="linux"
 libs "advapi32" platform="windows"
 

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -283,7 +283,7 @@ nothrow @safe version(mir_random_test) unittest
 /++
 Multinomial distribution.
 +/
-struct MultinomialVariable(U:ulong, T)
+struct MultinomialVariable(U:size_t, T)
     if (isFloatingPoint!T)
 {
     import mir.random.variable : binomialVar;
@@ -295,7 +295,7 @@ struct MultinomialVariable(U:ulong, T)
 
     ///
     const(T)[] probs;
-    const ulong N;
+    const size_t N;
 
     /++
     Params:
@@ -303,9 +303,7 @@ struct MultinomialVariable(U:ulong, T)
         N = Number of rolls
     Constraints: `sum(probs[i]) <= 1`
     +/
-
-    /// ditto
-    this()(const ulong N, const(T)[] probs)
+    this()(const size_t N, const(T)[] probs)
     {
         this.N = N;
         this.probs = probs;
@@ -313,7 +311,7 @@ struct MultinomialVariable(U:ulong, T)
 
     ///
     pragma(inline, false)
-    ulong[] opCall(G)(scope ref G gen, scope U[] result)
+    size_t[] opCall(G)(scope ref G gen, scope U[] result)
         if (isSaturatedRandomEngine!G)
     {
         uint k;
@@ -324,7 +322,7 @@ struct MultinomialVariable(U:ulong, T)
         alias rng = rne;
 
         uint sum_n = 0;
-        ulong[] n;
+        size_t[] n;
 
         /* p[k] may contain non-negative weights that do not sum to 1.0.
        * Even a probability distribution will not exactly sum to 1.0
@@ -341,6 +339,7 @@ struct MultinomialVariable(U:ulong, T)
         {
             if (p[k] > 0.0)
             {
+
                 auto rv = binomialVar(this.N - sum_n, p[k] / (norm - sum_p));
                 n[k] = rv(rng);
 
@@ -358,7 +357,7 @@ struct MultinomialVariable(U:ulong, T)
 
     }
     /// ditto
-    ulong[] opCall(G)(scope G* gen, scope U[] result)
+    size_t[] opCall(G)(scope G* gen, scope U[] result)
         if (isSaturatedRandomEngine!G)
     {
         pragma(inline, true);
@@ -381,11 +380,10 @@ alias multinomialVariable = multinomialVar;
 ///
 nothrow @safe version(mir_random_test) unittest
 {
-
-    ulong s = 1000;
+    size_t s = 1000;
     double[3] p =[1.0, 5.7, 0.3];
     auto rv = multinomialVar(s, p);
-    ulong[3] x;
+    size_t[3] x;
     x = rv(rne,x[]);
     //writeln(x);
     assert(x[0]+x[1]+x[2] == s);
@@ -395,9 +393,9 @@ nothrow @safe version(mir_random_test) unittest
 nothrow @safe version(mir_random_test) unittest
 {
     Random* gen = threadLocalPtr!Random;
-    ulong s = 1000;
-    auto rv = MultinomialVariable!(ulong,double)(s, [1.0, 5.7, 0.3]);
-    ulong[3] x;
+    size_t s = 1000;
+    auto rv = MultinomialVariable!(size_t,double)(s, [1.0, 5.7, 0.3]);
+    size_t[3] x;
     x = rv(gen,x[]);
     assert(x[0]+x[1]+x[2] == s);
 }

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -299,7 +299,7 @@ struct MultinomialVariable(U:size_t, T)
 
     /++
     Params:
-        probs = probabilities
+        probs = probabilities of the multinomial distribution
         N = Number of rolls
     Constraints: `sum(probs[i]) <= 1`
     +/
@@ -320,17 +320,13 @@ struct MultinomialVariable(U:size_t, T)
         alias rng = rne;
 
         uint sum_n = 0;
-        //size_t[] n;
 
-        /* p[k] may contain non-negative weights that do not sum to 1.0.
-       * Even a probability distribution will not exactly sum to 1.0
-       * due to rounding errors.
-       */
 
+        /// Makes sure probabilities add up to one, by calculating a normalization term
         foreach(k, p; this.probs)
         {
 
-            norm += p;//this.probs[k];
+            norm += p;
         }
 
         foreach(k, p; this.probs)
@@ -350,8 +346,7 @@ struct MultinomialVariable(U:size_t, T)
             sum_p += p;
             sum_n += result[k];
         }
-        //result = n;
-        //return result;
+
 
     }
     /// ditto
@@ -383,7 +378,6 @@ nothrow @safe version(mir_random_test) unittest
     auto rv = multinomialVar(s, p);
     size_t[3] x;
     rv(rne,x[]);
-    //writeln(x);
     assert(x[0]+x[1]+x[2] == s);
 }
 

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -296,7 +296,6 @@ struct MultinomialVariable(T)
     ///
     const(T)[] probs;
     size_t N;
-    double norm = 0.0;
 
 
     /++
@@ -334,7 +333,7 @@ struct MultinomialVariable(T)
         {
             if (p > 0.0)
             {
-                auto rv = binomialVar!T(this.N - sum_n, p / (this.norm - sum_p));
+                auto rv = binomialVar!T(this.N - sum_n, p / (1 - sum_p));
                 result[k] = cast(uint)rv(gen);
 
             }

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -314,10 +314,8 @@ struct MultinomialVariable(U:size_t, T)
     void opCall(G)(scope ref G gen, scope U[] result)
         if (isSaturatedRandomEngine!G)
     {
-        auto K = this.probs.length;
         double norm = 0.0;
         double sum_p = 0.0;
-        alias rng = rne;
 
         uint sum_n = 0;
 
@@ -325,7 +323,6 @@ struct MultinomialVariable(U:size_t, T)
         /// Makes sure probabilities add up to one, by calculating a normalization term
         foreach(k, p; this.probs)
         {
-
             norm += p;
         }
 
@@ -333,9 +330,8 @@ struct MultinomialVariable(U:size_t, T)
         {
             if (p > 0.0)
             {
-
                 auto rv = binomialVar!T(this.N - sum_n, p / (norm - sum_p));
-                result[k] = cast(uint)rv(rng);
+                result[k] = cast(uint)rv(gen);
 
             }
             else
@@ -373,12 +369,12 @@ alias multinomialVariable = multinomialVar;
 ///
 nothrow @safe version(mir_random_test) unittest
 {
-    size_t s = 1000;
-    double[3] p =[1.0, 5.7, 0.3];
+    size_t s = 10000;
+    double[6] p =[1/6., 1/6., 1/6, 1/6., 1/6., 1/6.];
     auto rv = multinomialVar(s, p);
-    size_t[3] x;
+    size_t[6] x;
     rv(rne,x[]);
-    assert(x[0]+x[1]+x[2] == s);
+    assert(x[0]+x[1]+x[2]+x[3]+x[4]+x[5] == s);
 }
 
 ///

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -7,6 +7,7 @@ $(BOOKTABLE $(H2 Multidimensional Random Variables),
     $(RVAR Sphere, Uniform distribution on a unit-sphere)
     $(RVAR Simplex, Uniform distribution on a standard-simplex)
     $(RVAR Dirichlet, $(WIKI_D Dirichlet))
+    $(RVAR Multinomial, $(WIKI_D Multinomial))
     $(RVAR MultivariateNormal, $(WIKI_D Multivariate_normal))
 )
 
@@ -282,7 +283,7 @@ nothrow @safe version(mir_random_test) unittest
 /++
 Multinomial distribution.
 +/
-struct MultinomialVariable(T)
+struct MultinomialVariable(U:ulong, T)
     if (isFloatingPoint!T)
 {
     import mir.random.variable : binomialVar;
@@ -312,7 +313,7 @@ struct MultinomialVariable(T)
 
     ///
     pragma(inline, false)
-    ulong[] opCall(G)(scope ref G gen, scope T[] result)
+    void opCall(G)(scope ref G gen, scope U[] result)
         if (isSaturatedRandomEngine!G)
     {
             uint k;
@@ -352,10 +353,10 @@ struct MultinomialVariable(T)
                 sum_p += p[k];
                 sum_n += n[k];
             }
-            return n;
+            result = n;
     }
     /// ditto
-    void opCall(G)(scope G* gen, scope T[] result)
+    void opCall(G)(scope G* gen, scope U[] result)
         if (isSaturatedRandomEngine!G)
     {
         pragma(inline, true);
@@ -364,7 +365,7 @@ struct MultinomialVariable(T)
 }
 
 /// ditto
-MultinomialVariable!T multinomialVar(T)(in T N, in T[] probs)
+MultinomialVariable!(U,T) multinomialVar(U, T)(in U N, in T[] probs)
     if (isFloatingPoint!T)
 {
     return typeof(return)(N, probs);
@@ -376,9 +377,12 @@ alias multinomialVariable = multinomialVar;
 ///
 nothrow @safe version(mir_random_test) unittest
 {
-    auto rv = multinomialVar(1000, [1.0, 5.7, 0.3]);
-    rv(rne);
-    assert(1==1);
+    ulong s = 1000;
+    double[3] p =[1.0, 5.7, 0.3];
+    auto rv = multinomialVar(s, p);
+    ulong[3] x;
+    rv(rne,x);
+    //assert(x[0]+x[1]+x[2] == s);
     assert(1==1);
 }
 
@@ -386,9 +390,11 @@ nothrow @safe version(mir_random_test) unittest
 nothrow @safe version(mir_random_test) unittest
 {
     Random* gen = threadLocalPtr!Random;
-    auto rv = MultinomialVariable!double(1000, [1.0, 5.7, 0.3]);
-    rv(gen);
-    assert(1==1);
+    ulong s = 1000;
+    auto rv = MultinomialVariable!(ulong,double)(s, [1.0, 5.7, 0.3]);
+    ulong[3] x;
+    rv(gen,x);
+    //assert(x[0]+x[1]+x[2] == s);
     assert(1==1);
 }
 

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -324,11 +324,11 @@ struct MultinomialVariable(T)
 
     ///
     pragma(inline, false)
-    void opCall(G)(scope ref G gen, scope size_t[] result)
+    void opCall(G)(scope ref G gen, scope uint[] result)
         if (isSaturatedRandomEngine!G)
     {
         T sum_p = 0.0;
-        uint sum_n = 0;
+        size_t sum_n = 0;
 
         foreach(k, p; this.probs)
         {
@@ -354,7 +354,7 @@ struct MultinomialVariable(T)
         if (isSaturatedRandomEngine!G)
     {
         pragma(inline, true);
-        return opCall(*gen, result);
+        opCall(*gen, result);
     }
 }
 
@@ -374,11 +374,21 @@ nothrow @safe version(mir_random_test) unittest
     size_t s = 10000;
     double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/6.]; // probs must add up to one
     auto rv = multinomialVar(s, p);
-    size_t[6] x;
-    rv(rne,x[]);
+    uint[6] x;
+    rv(rne, x[]);
     assert(x[0]+x[1]+x[2]+x[3]+x[4]+x[5] == s);
 }
 
+nothrow @safe version(mir_random_test) unittest
+{
+    Random* gen = threadLocalPtr!Random;
+    size_t s = 1000;
+    double[3] p = [0.1, 0.5, 0.4];
+    auto rv = MultinomialVariable!(double)(s, p);
+    uint[3] x;
+    rv(gen, x[]);
+    assert(x[0]+x[1]+x[2] == s);
+}
 
 /++
 Multivariate normal distribution.

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -328,10 +328,7 @@ struct MultinomialVariable(T)
         if (isSaturatedRandomEngine!G)
     {
         double sum_p = 0.0;
-
         uint sum_n = 0;
-
-
 
         foreach(k, p; this.probs)
         {
@@ -371,39 +368,16 @@ MultinomialVariable!(T) multinomialVar(T)(size_t N, return const T[] probs)
 /// ditto
 alias multinomialVariable = multinomialVar;
 
-
-
-
-//nothrow @safe version(mir_random_test) unittest
-//{
-//    size_t s = 10000;
-//    double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/16.]; // probs add to less than one
-//    auto rv = multinomialVar(s, p);
-//    size_t[6] x;
-//    rv(rne,x[]);
-//    assert(x[0]+x[1]+x[2]+x[3]+x[4]+x[5] == s);
-//}
-
 nothrow @safe version(mir_random_test) unittest
 {
     size_t s = 10000;
-    double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/6.]; // probs add to less than one
+    double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/6.]; // probs must add up to one
     auto rv = multinomialVar(s, p);
     size_t[6] x;
     rv(rne,x[]);
     assert(x[0]+x[1]+x[2]+x[3]+x[4]+x[5] == s);
 }
 
-///
-//nothrow @safe version(mir_random_test) unittest
-//{
-//    Random* gen = threadLocalPtr!Random;
-//    size_t s = 1000;
-//    auto rv = MultinomialVariable!(double)(s, [1.0, 5.7, 0.3]); // probs add to more than one
-//    size_t[3] x;
-//    rv(gen,x[]);
-//    assert(x[0]+x[1]+x[2] == s);
-//}
 
 /++
 Multivariate normal distribution.

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -310,11 +310,16 @@ struct MultinomialVariable(T)
         this.N = N;
         this.probs = probs;
          /// Makes sure probabilities add up to one, by calculating a normalization factor
-        foreach(k, p; this.probs)
+        version(assert)
         {
-            this.norm += p;
+            T norm = 0;
+            foreach(k, p; this.probs)
+        {
+            norm += p;
         }
-        //assert(fabs(this.norm - 1) <= double.min_normal * this.probs.length * 2);
+            assert(fabs(norm - 1) <= T.epsilon * probs.length * 2);
+        }
+
     }
 
     ///
@@ -368,11 +373,21 @@ alias multinomialVariable = multinomialVar;
 
 
 
-///
+
+//nothrow @safe version(mir_random_test) unittest
+//{
+//    size_t s = 10000;
+//    double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/16.]; // probs add to less than one
+//    auto rv = multinomialVar(s, p);
+//    size_t[6] x;
+//    rv(rne,x[]);
+//    assert(x[0]+x[1]+x[2]+x[3]+x[4]+x[5] == s);
+//}
+
 nothrow @safe version(mir_random_test) unittest
 {
     size_t s = 10000;
-    double[6] p =[1/6., 1/6., 1/6, 1/6., 1/6., 1/16.]; // probs add to less than one
+    double[6] p =[1/6., 1/6., 1/6., 1/6., 1/6., 1/6.]; // probs add to less than one
     auto rv = multinomialVar(s, p);
     size_t[6] x;
     rv(rne,x[]);
@@ -380,15 +395,15 @@ nothrow @safe version(mir_random_test) unittest
 }
 
 ///
-nothrow @safe version(mir_random_test) unittest
-{
-    Random* gen = threadLocalPtr!Random;
-    size_t s = 1000;
-    auto rv = MultinomialVariable!(double)(s, [1.0, 5.7, 0.3]); // probs add to more than one
-    size_t[3] x;
-    rv(gen,x[]);
-    assert(x[0]+x[1]+x[2] == s);
-}
+//nothrow @safe version(mir_random_test) unittest
+//{
+//    Random* gen = threadLocalPtr!Random;
+//    size_t s = 1000;
+//    auto rv = MultinomialVariable!(double)(s, [1.0, 5.7, 0.3]); // probs add to more than one
+//    size_t[3] x;
+//    rv(gen,x[]);
+//    assert(x[0]+x[1]+x[2] == s);
+//}
 
 /++
 Multivariate normal distribution.

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -327,7 +327,7 @@ struct MultinomialVariable(T)
     void opCall(G)(scope ref G gen, scope size_t[] result)
         if (isSaturatedRandomEngine!G)
     {
-        double sum_p = 0.0;
+        T sum_p = 0.0;
         uint sum_n = 0;
 
         foreach(k, p; this.probs)
@@ -350,7 +350,7 @@ struct MultinomialVariable(T)
 
     }
     /// ditto
-    void opCall(G)(scope G* gen, scope size_t[] result)
+    void opCall(G)(scope G* gen, scope uint[] result)
         if (isSaturatedRandomEngine!G)
     {
         pragma(inline, true);
@@ -368,6 +368,7 @@ MultinomialVariable!(T) multinomialVar(T)(size_t N, return const T[] probs)
 /// ditto
 alias multinomialVariable = multinomialVar;
 
+/// Tests if sample returned is of correct size.
 nothrow @safe version(mir_random_test) unittest
 {
     size_t s = 10000;

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -379,9 +379,9 @@ alias multinomialVariable = multinomialVar;
 
 
 ///
-@safe version(mir_random_test) unittest
+nothrow @safe version(mir_random_test) unittest
 {
-    import mir.ndslice.slice;
+
     ulong s = 1000;
     double[3] p =[1.0, 5.7, 0.3];
     auto rv = multinomialVar(s, p);
@@ -392,9 +392,8 @@ alias multinomialVariable = multinomialVar;
 }
 
 ///
-@safe version(mir_random_test) unittest
+nothrow @safe version(mir_random_test) unittest
 {
-    import mir.ndslice.slice;
     Random* gen = threadLocalPtr!Random;
     ulong s = 1000;
     auto rv = MultinomialVariable!(ulong,double)(s, [1.0, 5.7, 0.3]);

--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -314,9 +314,9 @@ struct MultinomialVariable(T)
         {
             T norm = 0;
             foreach(k, p; this.probs)
-        {
-            norm += p;
-        }
+            {
+                norm += p;
+            }
             assert(fabs(norm - 1) <= T.epsilon * probs.length * 2);
         }
 


### PR DESCRIPTION
I have ported this from GSL as described on issue #117.
it has been adapted to Mir-random API and has a simple unittest which are passing.

There is a minor deviation from the way other ndvariables in that the `opCall` is not void, but rather returns the result expected. I try but could not make it alter the result variable passed in in the outer scope, even though my implementation follows exactly the other variable's implementations. The only difference is that multinomial returns an array of long integers instead of doubles.
If there's a way to fix this, please let me know and I'll change the code, but as it is  the function works correctly. It is worth pointing out that the `opCall` of the scalar random variables, defined in `variable.d`, are also not void, returning the results directly.