### PR TITLE
Make MultivariateNormalVariable.cholesky public

### DIFF
--- a/source/mir/random/ndvariable.d
+++ b/source/mir/random/ndvariable.d
@@ -403,7 +403,7 @@ struct MultivariateNormalVariable(T)
     Compute Cholesky decomposition in place. Only accesses lower/left half of
     the matrix. Returns false if the matrix is not positive definite.
     +/
-    private static bool cholesky()(Slice!(T*, 2) m)
+    static bool cholesky()(Slice!(T*, 2) m)
     {
         import mir.algorithm.iteration: reduce;
         assert(m.length!0 == m.length!1);


### PR DESCRIPTION
to let user to check the input before constructing a MultivariateNormalVariable instance. In other case if the input is wrong `assert(0);` terminates the program.