### PR TITLE
Correct version dependency on mir-core

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ description "Dlang Random Number Generators"
 copyright "Copyright © 2016-2018, Ilya Yaroshenko (default), see also copyright per file"
 license "BSL-1.0 (default), Apache License, Version 2.0 for PCG"
 
-dependency "mir-core" version=">=0.2.0 <1.1.0"
+dependency "mir-core" version=">=0.2.0 <2.0.0"
 dependency "mir-linux-kernel" version="~>1.0.0"  platform="linux"
 libs "advapi32" platform="windows"
 


### PR DESCRIPTION
```
Currently, programs depending on mir-random and mir-algorithm are broken
(e.g. lubeck) because of the version specification.
While it looks very much like a bug in dub, there doesn't seem to be a
tangible reason to have the current version restriction:
if v1.0.0 works, any v1.x.y should work as well.
```

Currently Buildkite builds are broken because of this.