### PR TITLE
-preview=in: Replace 'in ref' with either 'in' or 'const scope ref'

### DIFF
--- a/examples/flex_plot/test_arcsine.d
+++ b/examples/flex_plot/test_arcsine.d
@@ -15,7 +15,7 @@ See_Also:
     $(LINK2 http://www.wolframalpha.com/input/?i=PDF%5BArcsineDistribution%5B0,+1%5D%5D,
     Wolfram Alpha)
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : log, pow, PI, sqrt;
     auto f0 = (S x) => cast(S) (-S(0.5) * log(-(x-1) * x) - log(PI));

--- a/examples/flex_plot/test_beta.d
+++ b/examples/flex_plot/test_beta.d
@@ -15,7 +15,7 @@ See_Also:
     $(LINK2 http://www.wolframalpha.com/input/?i=PDF%5BGammaDistribution%5B2,+5%5D%5D,
     Wolfram Alpha)
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : log, pow;
     auto f0 = (S x) => cast(S) log(30 * (1 - x).pow(x));

--- a/examples/flex_plot/test_density_at_boundaries.d
+++ b/examples/flex_plot/test_density_at_boundaries.d
@@ -10,7 +10,7 @@
 /**
 Test whether density vanishes at boundaries.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : log, pow;
     import std.conv : to;

--- a/examples/flex_plot/test_density_with_poles.d
+++ b/examples/flex_plot/test_density_with_poles.d
@@ -9,7 +9,7 @@
 /**
 Test density with pole.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : abs, log;
     auto f0 = (S x) => - cast(S) log(abs(x)) * S(0.5);

--- a/examples/flex_plot/test_different_c_values.d
+++ b/examples/flex_plot/test_different_c_values.d
@@ -9,7 +9,7 @@
 /**
 Test different values for c.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : pow;
     auto f0 = (S x) => -2 * pow(x, 4)  + 4 * x * x;

--- a/examples/flex_plot/test_double_dist.d
+++ b/examples/flex_plot/test_double_dist.d
@@ -9,7 +9,7 @@
 /**
 Default flex testing distribution.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : pow;
     import std.conv : to;

--- a/examples/flex_plot/test_gamma.d
+++ b/examples/flex_plot/test_gamma.d
@@ -14,7 +14,7 @@ See_Also:
     $(LINK2 http://www.wolframalpha.com/input/?i=PDF%5BGammaDistribution%5B4,+3%5D%5D,
     Wolfram Alpha)
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : log, pow, PI, sqrt;
     enum one_div_3 = S(1) / 3;

--- a/examples/flex_plot/test_inflection_point_at_boundary.d
+++ b/examples/flex_plot/test_inflection_point_at_boundary.d
@@ -9,7 +9,7 @@
 /**
 Test with inflection point at boundary.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : pow;
     auto f0 = (S x) => -pow(x, 4) + 6 * x * x;

--- a/examples/flex_plot/test_near_extrema.d
+++ b/examples/flex_plot/test_near_extrema.d
@@ -9,7 +9,7 @@
 /**
 Test at and near extrema.
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : pow;
     import std.conv : to;

--- a/examples/flex_plot/test_normal.d
+++ b/examples/flex_plot/test_normal.d
@@ -12,7 +12,7 @@ Normal distribution.
 See_Also:
     $(LINK2 https://en.wikipedia.org/wiki/Normal_distribution, Wikipedia)
 */
-void test(S, F)(in ref F test)
+void test(S, F)(in F test)
 {
     import std.math : exp, log, PI, sqrt;
     S[] points = [-S.infinity, -1.5, 0, 1.5, S.infinity];

--- a/source/mir/random/flex/internal/calc.d
+++ b/source/mir/random/flex/internal/calc.d
@@ -23,7 +23,7 @@ References:
     Hormann, W., J. Leydold, and G. Derflinger.
     "Automatic Nonuniform Random Number Generation." (2004): Formula 4.23
 */
-auto arcmean(S)(in ref Interval!S iv)
+auto arcmean(S)(const scope ref Interval!S iv)
 {
     import std.math: atan, tan;
     // Use at least double precision trigonometric functions.


### PR DESCRIPTION
```
Allow the code to compile with '-preview=in'.
In the test code, 'in ref' was replaced with simply 'in',
as the test code isn't much affected by the loss of 'ref'.
However, for the library code, the original meaning was retained.
```

In support of https://github.com/dlang/dmd/pull/11632 (so I can ensure projects compile and the switch is usable).